### PR TITLE
Configuration loading from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+config.ron
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,7 +226,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95da7392378178142f90c2b47681104ad96b99c43e6818ac09ed46087a9777ab"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -410,6 +422,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064ea8613fb712a19faf920022ec8ddf134984f100090764a4e1d768f3827f1f"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +489,8 @@ dependencies = [
  "log",
  "mcproto-rs",
  "rand 0.8.3",
+ "ron",
+ "serde",
  "simplelog",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ rand = "0.8.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 simplelog = "0.10.0"
+ron = "0.6.4"
+serde = "1.0.125"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,143 @@
+use std::{
+    default::Default,
+    fs::{
+        read_to_string,
+        File,
+    },
+    io,
+    path::Path,
+};
+
+use mcproto_rs::{
+    status::{
+        StatusPlayerSampleSpec,
+        StatusPlayersSpec,
+        StatusSpec,
+        StatusVersionSpec,
+    },
+    types::{
+        BaseComponent,
+        Chat,
+        TextComponent,
+    },
+    uuid::UUID4,
+};
+use ron::{
+    self,
+    de::from_str,
+    ser::{
+        self,
+        PrettyConfig,
+    },
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[derive(Serialize, Deserialize)]
+pub struct SplinterProxyConfiguration {
+    pub protocol_version: i32,
+    pub version: Option<(String, i32)>,
+    pub server_address: String,
+    pub bind_address: String,
+    pub max_players: Option<u32>,
+    pub status: SplinterProxyStatus,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SplinterProxyStatus {
+    pub player_count: Option<u32>,
+    pub player_sample: Option<Vec<(String, String)>>,
+    pub motd: String, // TextComponent,
+}
+
+impl Default for SplinterProxyConfiguration {
+    fn default() -> Self {
+        SplinterProxyConfiguration {
+            protocol_version: 753,
+            version: Some(("Splinter 1.16.3".into(), 753)),
+            server_address: "127.0.0.1:25400".into(),
+            bind_address: "127.0.0.1:25565".into(),
+            max_players: None,
+            status: SplinterProxyStatus::default(),
+        }
+    }
+}
+
+impl Default for SplinterProxyStatus {
+    fn default() -> Self {
+        SplinterProxyStatus {
+            player_count: None,
+            player_sample: Some(vec![]),
+            motd: "Splinter Proxy".into(), /* TextComponent {
+                                            * text: "Splinter Proxy".into(),
+                                            * base: BaseComponent::default(),
+                                            * }, */
+        }
+    }
+}
+
+pub enum ConfigLoadError {
+    NoFile,
+    Io(io::Error),
+    De(ron::Error),
+}
+
+pub enum ConfigSaveError {
+    Create(io::Error),
+    Write(ron::Error),
+}
+
+impl SplinterProxyConfiguration {
+    pub fn load(filepath: &Path) -> Result<SplinterProxyConfiguration, ConfigLoadError> {
+        if !filepath.is_file() {
+            return Err(ConfigLoadError::NoFile);
+        }
+        let data = read_to_string(filepath).map_err(|e| ConfigLoadError::Io(e))?;
+        from_str(data.as_str()).map_err(|e| ConfigLoadError::De(e))
+    }
+    pub fn save(&self, filepath: &Path) -> Result<(), ConfigSaveError> {
+        let file = File::create(&filepath).map_err(|e| ConfigSaveError::Create(e))?;
+        ser::to_writer_pretty(file, self, PrettyConfig::default())
+            .map_err(|e| ConfigSaveError::Write(e))
+    }
+    pub fn server_status(&self, total_players: Option<u32>) -> StatusSpec {
+        StatusSpec {
+            version: self
+                .version
+                .as_ref()
+                .map(|(name, protocol)| StatusVersionSpec {
+                    name: name.clone(),
+                    protocol: *protocol,
+                }),
+            players: StatusPlayersSpec {
+                max: self
+                    .max_players
+                    .unwrap_or_else(|| total_players.unwrap_or(0) + 1) as i32,
+                online: total_players.unwrap_or(0) as i32,
+                sample: self
+                    .status
+                    .player_sample
+                    .as_ref()
+                    .map(|samples| {
+                        samples
+                            .iter()
+                            .map(|(name, id)| StatusPlayerSampleSpec {
+                                name: name.clone(),
+                                id: UUID4::parse(id).unwrap_or(UUID4::random()),
+                            })
+                            .collect::<Vec<StatusPlayerSampleSpec>>()
+                    })
+                    .unwrap_or_else(
+                        || vec![], // should put the actual players of the server here
+                    ),
+            },
+            description: Chat::Text(TextComponent {
+                text: self.status.motd.clone(),
+                base: BaseComponent::default(),
+            }), // Chat::Text(self.status.motd.clone()),
+            favicon: None,
+        }
+    }
+}


### PR DESCRIPTION
Proxy loads configuration from a `config.ron`. If none, creates one from defaults.
```
(
    protocol_version: 753,
    version: Some(("Splinter 1.16.3", 753)),
    server_address: "127.0.0.1:25400",
    bind_address: "127.0.0.1:25565",
    max_players: None,
    status: (
        player_count: None,
        player_sample: Some([]),
        motd: "Splinter Proxy",
    ),
)
```