### PR TITLE
Refactoring, move some connection code to connection.rs

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,18 +1,40 @@
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{
+        mpsc::{
+            Receiver,
+            Sender,
+        },
+        Arc,
+        RwLock,
+    },
 };
 
 use craftio_rs::{
+    CraftSyncReader,
     CraftSyncWriter,
     CraftTcpConnection,
 };
-use mcproto_rs::v1_16_3::{
-    Packet753 as PacketLatest,
-    RawPacket753 as RawPacketLatest,
+use mcproto_rs::{
+    protocol::{
+        HasPacketId,
+        Id,
+        RawPacket,
+    },
+    v1_16_3::{
+        Packet753 as PacketLatest,
+        RawPacket753 as RawPacketLatest,
+    },
 };
 
-use crate::config::SplinterProxyConfiguration;
+use crate::{
+    config::SplinterProxyConfiguration,
+    mapping::{
+        process_raw_packet,
+        MapAction,
+        PacketMap,
+    },
+};
 
 pub struct SplinterClientConnection {
     pub craft_conn: CraftTcpConnection,
@@ -62,4 +84,83 @@ impl HasCraftConn for SplinterServerConnection {
     fn sock_addr(&self) -> SocketAddr {
         self.sock_addr
     }
+}
+
+pub enum EitherPacket {
+    Normal(PacketLatest),
+    Raw(Id, Vec<u8>),
+}
+
+pub fn handle_reader(
+    is_alive: Arc<RwLock<bool>>,
+    mut reader: impl CraftSyncReader,
+    packet_map: Arc<PacketMap>,
+    writer_sender: Sender<EitherPacket>,
+    server_writer_sender: Sender<EitherPacket>,
+    client_writer_sender: Sender<EitherPacket>,
+    client_name: String,
+) {
+    while *is_alive.read().unwrap() {
+        match reader.read_raw_packet::<RawPacketLatest>() {
+            Ok(Some(raw_packet)) => match process_raw_packet(&*packet_map, raw_packet) {
+                MapAction::Relay(raw_packet) => {
+                    if let Err(_) = writer_sender.send(EitherPacket::Raw(
+                        raw_packet.id(),
+                        raw_packet.data().to_owned(),
+                    )) {
+                        break;
+                    }
+                }
+                MapAction::Server(packet) => {
+                    if let Err(_) = server_writer_sender.send(EitherPacket::Normal(packet)) {
+                        break;
+                    }
+                }
+                MapAction::Client(packet) => {
+                    if let Err(_) = client_writer_sender.send(EitherPacket::Normal(packet)) {
+                        break;
+                    }
+                }
+                MapAction::None => {}
+            },
+            Ok(None) => {
+                trace!("One connection closed for {}", client_name);
+                break;
+            }
+            Err(e) => {
+                error!("Failed to read packet for {}: {}", client_name, e);
+            }
+        }
+    }
+    *is_alive.write().unwrap() = false;
+    trace!("reader thread closed for {}", client_name);
+}
+
+pub fn handle_writer(
+    is_alive: Arc<RwLock<bool>>,
+    client_name: String,
+    writer_receiver: Receiver<EitherPacket>,
+    mut writer: impl CraftSyncWriter,
+) {
+    let mut recv = writer_receiver.iter();
+    while *is_alive.read().unwrap() {
+        match recv.next() {
+            Some(packet) => {
+                if let Err(e) = match packet {
+                    EitherPacket::Normal(packet) => writer.write_packet(packet),
+                    EitherPacket::Raw(id, data) => {
+                        match RawPacketLatest::create(id, data.as_slice()) {
+                            Ok(packet) => writer.write_raw_packet(packet),
+                            Err(_e) => continue,
+                        }
+                    }
+                } {
+                    error!("Failed to send packet for {}: {}", client_name, e);
+                }
+            }
+            None => break,
+        }
+    }
+    *is_alive.write().unwrap() = false;
+    trace!("writer thread closed for {}", client_name);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,24 +139,24 @@ fn main() {
     info!("Starting Splinter proxy");
 
     let mut map: PacketMap = HashMap::new();
-    map.insert(
-        PacketLatestKind::PlayBlockChange,
-        Box::new(|raw_packet: RawPacketLatest| {
-            let packet = match raw_packet.deserialize() {
-                Ok(packet) => packet,
-                Err(e) => {
-                    error!("Failed to deserialize packet: {}", e);
-                    return MapAction::None;
-                }
-            };
-            if let PacketLatest::PlayBlockChange(mut data) = packet {
-                data.block_id = 5.into();
-                MapAction::Client(PacketLatest::PlayBlockChange(data))
-            } else {
-                MapAction::Client(packet)
-            }
-        }),
-    );
+    // map.insert(
+    //    PacketLatestKind::PlayBlockChange,
+    //    Box::new(|raw_packet: RawPacketLatest| {
+    //        let packet = match raw_packet.deserialize() {
+    //            Ok(packet) => packet,
+    //            Err(e) => {
+    //                error!("Failed to deserialize packet: {}", e);
+    //                return MapAction::None;
+    //            }
+    //        };
+    //        if let PacketLatest::PlayBlockChange(mut data) = packet {
+    //            data.block_id = 5.into();
+    //            MapAction::Client(PacketLatest::PlayBlockChange(data))
+    //        } else {
+    //            MapAction::Client(packet)
+    //        }
+    //    }),
+    //);
 
     let packet_map: Arc<PacketMap> = Arc::new(map);
     let config = get_config("./config.ron");
@@ -378,8 +378,8 @@ fn handle_login(mut client: SplinterClientConnection, packet_map: Arc<PacketMap>
         Err(e) => return error!("Failed to read packet from client for {}: {}", name, e),
     }
 
-    let (mut server_reader, mut server_writer) = server.craft_conn.into_split(); // proxy's connection to the server
-    let (mut client_reader, mut client_writer) = client.craft_conn.into_split(); // proxy's connection to the client
+    let (server_reader, server_writer) = server.craft_conn.into_split(); // proxy's connection to the server
+    let (client_reader, client_writer) = client.craft_conn.into_split(); // proxy's connection to the client
     let (server_writer_sender, server_writer_receiver) = mpsc::channel::<EitherPacket>();
     let (client_writer_sender, client_writer_receiver) = mpsc::channel::<EitherPacket>();
     let is_alive_arc = Arc::new(RwLock::new(true));

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,9 @@ use simplelog::{
 
 mod connection;
 use crate::connection::{
+    handle_reader,
+    handle_writer,
+    EitherPacket,
     HasCraftConn,
     SplinterClientConnection,
     SplinterServerConnection,
@@ -82,12 +85,6 @@ use crate::mapping::{
     MapAction,
     PacketMap,
 };
-
-enum EitherPacket {
-    Normal(PacketLatest),
-    // Raw(RawPacketLatest<'a>),
-    Raw(Id, Vec<u8>),
-}
 
 fn get_config(config_path: &str) -> Arc<SplinterProxyConfiguration> {
     let config = match SplinterProxyConfiguration::load(Path::new(config_path)) {
@@ -141,34 +138,32 @@ fn main() {
     .expect("Logger failed to initialize");
     info!("Starting Splinter proxy");
 
-    let packet_map: Arc<RwLock<PacketMap>> = Arc::new(RwLock::new(HashMap::new()));
-    {
-        let mut map = packet_map.write().unwrap();
+    let mut map: PacketMap = HashMap::new();
+    map.insert(
+        PacketLatestKind::PlayBlockChange,
+        Box::new(|raw_packet: RawPacketLatest| {
+            let packet = match raw_packet.deserialize() {
+                Ok(packet) => packet,
+                Err(e) => {
+                    error!("Failed to deserialize packet: {}", e);
+                    return MapAction::None;
+                }
+            };
+            if let PacketLatest::PlayBlockChange(mut data) = packet {
+                data.block_id = 5.into();
+                MapAction::Client(PacketLatest::PlayBlockChange(data))
+            } else {
+                MapAction::Client(packet)
+            }
+        }),
+    );
 
-        // map.insert(
-        //    PacketLatestKind::PlayBlockChange,
-        //    Arc::new(|raw_packet: RawPacketLatest| {
-        //        let packet = match raw_packet.deserialize() {
-        //            Ok(packet) => packet,
-        //            Err(e) => {
-        //                error!("Failed to deserialize packet: {}", e);
-        //                return MapAction::None;
-        //            }
-        //        };
-        //        if let PacketLatest::PlayBlockChange(mut data) = packet {
-        //            data.block_id = 5.into();
-        //            MapAction::Client(PacketLatest::PlayBlockChange(data))
-        //        } else {
-        //            MapAction::Client(packet)
-        //        }
-        //    }),
-        //);
-    }
+    let packet_map: Arc<PacketMap> = Arc::new(map);
     let config = get_config("./config.ron");
     listen_for_clients(config, packet_map);
 }
 
-fn listen_for_clients(config: Arc<SplinterProxyConfiguration>, packet_map: Arc<RwLock<PacketMap>>) {
+fn listen_for_clients(config: Arc<SplinterProxyConfiguration>, packet_map: Arc<PacketMap>) {
     let listener = match TcpListener::bind(&config.bind_address) {
         Err(e) => {
             return error!(
@@ -212,7 +207,7 @@ fn listen_for_clients(config: Arc<SplinterProxyConfiguration>, packet_map: Arc<R
     }
 }
 
-fn await_handshake(mut conn: SplinterClientConnection, packet_map: Arc<RwLock<PacketMap>>) {
+fn await_handshake(mut conn: SplinterClientConnection, packet_map: Arc<PacketMap>) {
     match conn.craft_conn.read_raw_packet::<RawPacketLatest>() {
         Ok(Some(RawPacketLatest::Handshake(handshake_body))) => {
             match handshake_body.deserialize() {
@@ -279,7 +274,7 @@ fn handle_status(mut conn: SplinterClientConnection) {
     }
 }
 
-fn handle_login(mut client: SplinterClientConnection, packet_map: Arc<RwLock<PacketMap>>) {
+fn handle_login(mut client: SplinterClientConnection, packet_map: Arc<PacketMap>) {
     client.craft_conn.set_state(State::Login);
     let logindata;
     loop {
@@ -393,75 +388,28 @@ fn handle_login(mut client: SplinterClientConnection, packet_map: Arc<RwLock<Pac
         let packet_map = packet_map.clone();
         let is_alive_arc = is_alive_arc.clone();
         let name = name.clone();
+        let writer_sender = server_writer_sender.clone();
         let server_writer_sender = server_writer_sender.clone();
         let client_writer_sender = client_writer_sender.clone();
         thread::spawn(move || {
-            while *is_alive_arc.read().unwrap() {
-                match client_reader.read_raw_packet::<RawPacketLatest>() {
-                    Ok(Some(raw_packet)) => {
-                        match process_raw_packet(&packet_map.read().unwrap(), raw_packet) {
-                            MapAction::Relay(raw_packet) => {
-                                match server_writer_sender.send(EitherPacket::Raw(
-                                    raw_packet.id(),
-                                    raw_packet.data().to_owned(),
-                                )) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::Server(packet) => {
-                                match server_writer_sender.send(EitherPacket::Normal(packet)) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::Client(packet) => {
-                                match client_writer_sender.send(EitherPacket::Normal(packet)) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::None => {}
-                        }
-                    }
-                    Ok(None) => {
-                        info!("Client connection closed for {}", name);
-                        break;
-                    }
-                    Err(e) => {
-                        // not sure if we should be doing something here
-                        error!("Failed to read packet client to server for {}: {}", name, e);
-                    }
-                }
-            }
-            *is_alive_arc.write().unwrap() = false;
-            trace!("client to server thread closed for {}", name);
+            handle_reader(
+                is_alive_arc,
+                client_reader,
+                packet_map,
+                writer_sender,
+                server_writer_sender,
+                client_writer_sender,
+                name,
+            )
         });
     }
+
     // server writer
     {
         let is_alive_arc = is_alive_arc.clone();
         let name = name.clone();
         thread::spawn(move || {
-            let mut recv = server_writer_receiver.iter();
-            while *is_alive_arc.read().unwrap() {
-                match recv.next() {
-                    Some(packet) => match match packet {
-                        EitherPacket::Normal(packet) => server_writer.write_packet(packet),
-                        EitherPacket::Raw(id, data) => {
-                            match RawPacketLatest::create(id, data.as_slice()) {
-                                Ok(packet) => server_writer.write_raw_packet(packet),
-                                Err(_e) => continue,
-                            }
-                        }
-                    } {
-                        Ok(()) => {}
-                        Err(e) => error!("Failed to relay packet to server for {}: {}", name, e),
-                    },
-                    None => break,
-                }
-            }
-            *is_alive_arc.write().unwrap() = false;
+            handle_writer(is_alive_arc, name, server_writer_receiver, server_writer)
         });
     }
 
@@ -470,73 +418,23 @@ fn handle_login(mut client: SplinterClientConnection, packet_map: Arc<RwLock<Pac
         let packet_map = packet_map.clone();
         let is_alive_arc = is_alive_arc.clone();
         let name = name.clone();
+        let writer_sender = client_writer_sender.clone();
         let server_writer_sender = server_writer_sender.clone();
         let client_writer_sender = client_writer_sender.clone();
         thread::spawn(move || {
-            while *is_alive_arc.read().unwrap() {
-                match server_reader.read_raw_packet::<RawPacketLatest>() {
-                    Ok(Some(raw_packet)) => {
-                        match process_raw_packet(&packet_map.read().unwrap(), raw_packet) {
-                            MapAction::Relay(raw_packet) => {
-                                match client_writer_sender.send(EitherPacket::Raw(
-                                    raw_packet.id(),
-                                    raw_packet.data().to_owned(),
-                                )) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::Server(packet) => {
-                                match server_writer_sender.send(EitherPacket::Normal(packet)) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::Client(packet) => {
-                                match client_writer_sender.send(EitherPacket::Normal(packet)) {
-                                    Ok(()) => {}
-                                    Err(_e) => break,
-                                }
-                            }
-                            MapAction::None => {}
-                        }
-                    }
-                    Ok(None) => {
-                        info!("Server connection closed for {}", name);
-                        break;
-                    }
-                    Err(e) => {
-                        // not sure if we should be doing something here
-                        error!("Failed to read packet server to client for {}: {}", name, e);
-                    }
-                };
-            }
-            *is_alive_arc.write().unwrap() = false;
-            trace!("server to client thread closed for {}", name);
+            handle_reader(
+                is_alive_arc,
+                server_reader,
+                packet_map,
+                writer_sender,
+                server_writer_sender,
+                client_writer_sender,
+                name,
+            )
         });
     }
     // client writer
     let is_alive_arc = is_alive_arc.clone();
     let name = name.clone();
-    thread::spawn(move || {
-        let mut recv = client_writer_receiver.iter();
-        while *is_alive_arc.read().unwrap() {
-            match recv.next() {
-                Some(packet) => match match packet {
-                    EitherPacket::Normal(packet) => client_writer.write_packet(packet),
-                    EitherPacket::Raw(id, data) => {
-                        match RawPacketLatest::create(id, data.as_slice()) {
-                            Ok(packet) => client_writer.write_raw_packet(packet),
-                            Err(_e) => continue,
-                        }
-                    }
-                } {
-                    Ok(()) => {}
-                    Err(e) => error!("Failed to relay packet to client for {}: {}", name, e),
-                },
-                None => break,
-            }
-        }
-        *is_alive_arc.write().unwrap() = false;
-    });
+    thread::spawn(move || handle_writer(is_alive_arc, name, client_writer_receiver, client_writer));
 }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -22,8 +22,8 @@ pub enum MapAction<'a> {
     None,
 }
 
-pub type PacketMap =
-    HashMap<PacketLatestKind, Arc<dyn Sync + Send + Fn(RawPacketLatest) -> MapAction>>;
+pub type PacketMapFn = Box<dyn Sync + Send + Fn(RawPacketLatest) -> MapAction>;
+pub type PacketMap = HashMap<PacketLatestKind, PacketMapFn>;
 
 pub fn process_raw_packet<'a>(
     map: &'a PacketMap,


### PR DESCRIPTION
Moves the readers and writers to connection.rs, general function for reader and writer each.
Change `Arc<RwLock<PacketMap>>` to `Arc<PacketMap>`
Change `PacketMap`'s `Arc` around its functions to a `Box`