### PR TITLE
Chat and refactor

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,32 +1,59 @@
+use craftio_rs::CraftSyncWriter;
 use mcproto_rs::{
     protocol::RawPacket,
+    types::{
+        BaseComponent,
+        Chat,
+        TextComponent,
+    },
     v1_16_3::{
+        ChatPosition,
         Packet753 as PacketLatest,
         Packet753Kind as PacketLatestKind,
+        PlayServerChatMessageSpec,
         RawPacket753 as RawPacketLatest,
     },
 };
 
-use crate::mapping::{
-    MapAction,
-    PacketMap,
+use crate::{
+    mapping::PacketMap,
+    state::SplinterState,
 };
 
+/// Initializes chat handling
 pub fn init(map: &mut PacketMap) {
     map.insert(
         PacketLatestKind::PlayClientChatMessage,
-        Box::new(|state, raw_packet| {
-            let packet = match raw_packet.deserialize() {
-                Ok(packet) => packet,
+        Box::new(|client, state: &SplinterState, raw_packet| {
+            match raw_packet.deserialize() {
+                Ok(packet) => {
+                    if let PacketLatest::PlayClientChatMessage(data) = packet {
+                        let message = format!("{}: {}", client.name, data.message);
+                        info!("{}", message);
+                        for (id, target) in state.players.read().unwrap().iter() {
+                            if let Err(e) = target.writer.lock().unwrap().write_packet(
+                                PacketLatest::PlayServerChatMessage(PlayServerChatMessageSpec {
+                                    message: Chat::Text(TextComponent {
+                                        text: message.clone(),
+                                        base: BaseComponent::default(),
+                                    }),
+                                    position: ChatPosition::ChatBox,
+                                    sender: client.uuid,
+                                }),
+                            ) {
+                                error!(
+                                    "Failed to send chat message from {} to {}",
+                                    client.name, target.name
+                                );
+                            }
+                        }
+                    }
+                }
                 Err(e) => {
                     error!("failed to deserialize chat message from player: {}", e);
-                    return MapAction::None;
                 }
             };
-            if let PacketLatest::PlayClientChatMessage(data) = packet {
-                info!("got chat message: {}", data.message);
-            }
-            MapAction::None
+            false
         }),
     );
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,0 +1,32 @@
+use mcproto_rs::{
+    protocol::RawPacket,
+    v1_16_3::{
+        Packet753 as PacketLatest,
+        Packet753Kind as PacketLatestKind,
+        RawPacket753 as RawPacketLatest,
+    },
+};
+
+use crate::mapping::{
+    MapAction,
+    PacketMap,
+};
+
+pub fn init(map: &mut PacketMap) {
+    map.insert(
+        PacketLatestKind::PlayClientChatMessage,
+        Box::new(|state, raw_packet| {
+            let packet = match raw_packet.deserialize() {
+                Ok(packet) => packet,
+                Err(e) => {
+                    error!("failed to deserialize chat message from player: {}", e);
+                    return MapAction::None;
+                }
+            };
+            if let PacketLatest::PlayClientChatMessage(data) = packet {
+                info!("got chat message: {}", data.message);
+            }
+            MapAction::None
+        }),
+    );
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,6 +20,7 @@ use mcproto_rs::{
         HasPacketId,
         HasPacketKind,
         Id,
+        PacketDirection,
         RawPacket,
     },
     v1_16_3::{
@@ -107,26 +108,24 @@ pub enum EitherPacket {
 
 /// Handles reading a connection and deciding what to do with data
 ///
+/// `client` contains the state of the client.
+///
+/// `state` is the state of the proxy.
+///
 /// `is_alive` is a [`Arc`]<[`RwLock`]<[`bool`]>>. The as long as `is_alive` is true, then the reader
 /// will continue reading. The reader can also turn off `is_alive` itself.
 ///
 /// `packet_map` is an [`Arc`]<[`PacketMap`]> so that it can correctly determine what to do with certain packets.
-/// `writer_sender`, `server_writer_sender`, and `client_writer_sender` are [`Sender`]<[`EitherPacket`]>.
-/// `writer_sender` is the sender to wherever the original packet was going, for example if the
-/// packet were original client bound, then `writer_sender` would be a clone of
-/// `client_writer_sender`.
 ///
-/// `client_name` is the user name of the client.
+/// `direction` is the packet flow, whether packets are coming from server (client bound) or coming
+/// from client (server bound)
 pub fn handle_reader(
     client: Arc<SplinterClient>,
     state: Arc<SplinterState>,
     is_alive: Arc<RwLock<bool>>,
     mut reader: impl CraftSyncReader,
     packet_map: Arc<PacketMap>,
-    writer_sender: Sender<EitherPacket>,
-    server_writer_sender: Sender<EitherPacket>,
-    client_writer_sender: Sender<EitherPacket>,
-    client_name: String,
+    direction: PacketDirection,
 ) {
     while *is_alive.read().unwrap() {
         match reader.read_raw_packet::<RawPacketLatest>() {
@@ -135,61 +134,28 @@ pub fn handle_reader(
                     Some(entry) => entry(&*client, &*state, &raw_packet),
                     None => true,
                 } {
-                    if let Err(e) = writer_sender.send(EitherPacket::Raw(
-                        raw_packet.id(),
-                        raw_packet.data().to_owned(),
-                    )) {
-                        error!("failed to send packet: {}", e);
+                    if let Err(e) = match direction {
+                        PacketDirection::ClientBound => {
+                            client.writer.lock().unwrap().write_raw_packet(raw_packet)
+                        }
+                        PacketDirection::ServerBound => client.servers.read().unwrap()[0]
+                            .writer
+                            .lock()
+                            .unwrap()
+                            .write_raw_packet(raw_packet),
+                    } {
+                        error!("Failed to send packet for {}: {:?}", client.name, direction);
                     }
                 }
             }
             Ok(None) => {
-                trace!("One connection closed for {}", client_name);
                 break;
             }
             Err(e) => {
-                error!("Failed to read packet for {}: {}", client_name, e);
+                error!("Failed to read packet for {}: {}", client.name, e);
             }
         }
     }
     *is_alive.write().unwrap() = false;
-    trace!("reader thread closed for {}", client_name);
-}
-
-/// Handles reading a connection and deciding what to do with data
-///
-/// `is_alive` is a [`Arc`]<[`RwLock`]<[`bool`]>>. The as long as `is_alive` is true, then the reader
-/// will continue reading. The reader can also turn off `is_alive` itself.
-///
-/// `client_name` is the user name of the client.
-///
-/// `writer_receiver` is a [`Receiver`]<[`EitherPacket`]> to receive any packets that are sent to this writer.
-pub fn handle_writer(
-    state: Arc<SplinterState>,
-    is_alive: Arc<RwLock<bool>>,
-    client_name: String,
-    writer_receiver: Receiver<EitherPacket>,
-    mut writer: impl CraftSyncWriter,
-) {
-    let mut recv = writer_receiver.iter();
-    while *is_alive.read().unwrap() {
-        match recv.next() {
-            Some(packet) => {
-                if let Err(e) = match packet {
-                    EitherPacket::Normal(packet) => writer.write_packet(packet),
-                    EitherPacket::Raw(id, data) => {
-                        match RawPacketLatest::create(id, data.as_slice()) {
-                            Ok(packet) => writer.write_raw_packet(packet),
-                            Err(_e) => continue,
-                        }
-                    }
-                } {
-                    error!("Failed to send packet for {}: {}", client_name, e);
-                }
-            }
-            None => break,
-        }
-    }
-    *is_alive.write().unwrap() = false;
-    trace!("writer thread closed for {}", client_name);
+    trace!("reader thread closed for {}", client.name);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,23 +144,31 @@ fn main() {
 
     let mut map: PacketMap = HashMap::new();
     // map.insert(
-    //    PacketLatestKind::PlayBlockChange,
-    //    Box::new(|raw_packet: RawPacketLatest| {
-    //        let packet = match raw_packet.deserialize() {
-    //            Ok(packet) => packet,
-    //            Err(e) => {
-    //                error!("Failed to deserialize packet: {}", e);
-    //                return MapAction::None;
-    //            }
-    //        };
-    //        if let PacketLatest::PlayBlockChange(mut data) = packet {
-    //            data.block_id = 5.into();
-    //            MapAction::Client(PacketLatest::PlayBlockChange(data))
-    //        } else {
-    //            MapAction::Client(packet)
-    //        }
-    //    }),
-    //);
+    //     PacketLatestKind::PlayBlockChange,
+    //     Box::new(|state: Arc<SplinterState>, raw_packet: RawPacketLatest| {
+    //         info!("blockupdate");
+
+    //         let packet = match raw_packet.deserialize() {
+    //             Ok(packet) => packet,
+    //             Err(e) => {
+    //                 error!("Failed to deserialize packet: {}", e);
+    //                 return MapAction::None;
+    //             }
+    //         };
+
+    //         {
+    //             let mut d = state.id.write().unwrap();
+    //             *d += 1;
+    //         }
+
+    //         if let PacketLatest::PlayBlockChange(mut data) = packet {
+    //             data.block_id = (*state.id.read().unwrap()).into();
+    //             MapAction::Client(PacketLatest::PlayBlockChange(data))
+    //         } else {
+    //             MapAction::Client(packet)
+    //         }
+    //     }),
+    // );
 
     let packet_map: Arc<PacketMap> = Arc::new(map);
     let state = SplinterState::new(get_config("./config.ron"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,14 +81,13 @@ use crate::config::{
 };
 
 mod mapping;
-use crate::mapping::{
-    process_raw_packet,
-    MapAction,
-    PacketMap,
-};
+use crate::mapping::PacketMap;
 
 mod state;
 use crate::state::SplinterState;
+
+mod chat;
+use crate::chat::init;
 
 fn get_config(config_path: &str) -> SplinterProxyConfiguration {
     let config = match SplinterProxyConfiguration::load(Path::new(config_path)) {
@@ -143,6 +142,8 @@ fn main() {
     info!("Starting Splinter proxy");
 
     let mut map: PacketMap = HashMap::new();
+    chat::init(&mut map);
+
     // map.insert(
     //     PacketLatestKind::PlayBlockChange,
     //     Box::new(|state: Arc<SplinterState>, raw_packet: RawPacketLatest| {

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -15,6 +15,8 @@ use mcproto_rs::{
     },
 };
 
+use crate::state::SplinterState;
+
 pub enum MapAction<'a> {
     Relay(RawPacketLatest<'a>),
     Server(PacketLatest), // TODO: will have to do like a server id or something
@@ -22,15 +24,16 @@ pub enum MapAction<'a> {
     None,
 }
 
-pub type PacketMapFn = Box<dyn Sync + Send + Fn(RawPacketLatest) -> MapAction>;
+pub type PacketMapFn = Box<dyn Sync + Send + Fn(Arc<SplinterState>, RawPacketLatest) -> MapAction>;
 pub type PacketMap = HashMap<PacketLatestKind, PacketMapFn>;
 
 pub fn process_raw_packet<'a>(
+    state: Arc<SplinterState>,
     map: &'a PacketMap,
     raw_packet: RawPacketLatest<'a>,
 ) -> MapAction<'a> {
     return match map.get(&raw_packet.kind()) {
-        Some(entry) => entry(raw_packet),
+        Some(entry) => entry(state, raw_packet),
         None => MapAction::Relay::<'a>(raw_packet),
     };
 }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -15,25 +15,11 @@ use mcproto_rs::{
     },
 };
 
-use crate::state::SplinterState;
+use crate::state::{
+    SplinterClient,
+    SplinterState,
+};
 
-pub enum MapAction<'a> {
-    Relay(RawPacketLatest<'a>),
-    Server(PacketLatest), // TODO: will have to do like a server id or something
-    Client(PacketLatest),
-    None,
-}
-
-pub type PacketMapFn = Box<dyn Sync + Send + Fn(Arc<SplinterState>, RawPacketLatest) -> MapAction>;
+pub type PacketMapFn =
+    Box<dyn Sync + Send + Fn(&SplinterClient, &SplinterState, &RawPacketLatest) -> bool>;
 pub type PacketMap = HashMap<PacketLatestKind, PacketMapFn>;
-
-pub fn process_raw_packet<'a>(
-    state: Arc<SplinterState>,
-    map: &'a PacketMap,
-    raw_packet: RawPacketLatest<'a>,
-) -> MapAction<'a> {
-    return match map.get(&raw_packet.kind()) {
-        Some(entry) => entry(state, raw_packet),
-        None => MapAction::Relay::<'a>(raw_packet),
-    };
-}

--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,10 @@ pub struct SplinterState {
     pub id: RwLock<i32>,
 }
 
+pub struct SplinterClient {
+    pub name: String,
+}
+
 impl SplinterState {
     pub fn new(config: SplinterProxyConfiguration) -> Arc<SplinterState> {
         Arc::new(SplinterState {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,29 +1,62 @@
 use std::{
     self,
+    collections::HashMap,
+    net::{
+        SocketAddr,
+        TcpStream,
+    },
     sync::{
         Arc,
+        Mutex,
         RwLock,
     },
 };
 
+use craftio_rs::CraftWriter;
+use mcproto_rs::uuid::UUID4;
+
 use crate::config::SplinterProxyConfiguration;
 
+/// Global state for the splinter proxy
 pub struct SplinterState {
+    /// Configuration
     pub config: RwLock<SplinterProxyConfiguration>,
-    pub player_count: RwLock<u32>,
-    pub id: RwLock<i32>,
+    /// List of client states
+    pub players: RwLock<HashMap<u64, Arc<SplinterClient>>>,
 }
 
+/// Client state
 pub struct SplinterClient {
+    /// Internal unique ID of the client
+    pub id: u64,
+    /// Username of the client
     pub name: String,
+    /// List of connections to servers
+    pub servers: RwLock<Vec<SplinterServer>>,
+    /// Writer to the client
+    pub writer: Mutex<CraftWriter<TcpStream>>,
+    /// Proxy's UUID of the client
+    pub uuid: UUID4,
+}
+
+/// Server state specific to client-proxy-server
+pub struct SplinterServer {
+    /// Internal unique ID of the server
+    pub id: u64,
+    /// Address of the server
+    pub addr: SocketAddr,
+    /// Writer to the server
+    pub writer: Mutex<CraftWriter<TcpStream>>,
+    /// Server's UUID for the client
+    pub client_uuid: UUID4,
 }
 
 impl SplinterState {
+    /// Creates a new splinter state given the proxy configuration
     pub fn new(config: SplinterProxyConfiguration) -> Arc<SplinterState> {
         Arc::new(SplinterState {
             config: RwLock::new(config),
-            player_count: RwLock::new(0),
-            id: RwLock::new(0),
+            players: RwLock::new(HashMap::new()),
         })
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,7 @@ use crate::config::SplinterProxyConfiguration;
 pub struct SplinterState {
     pub config: RwLock<SplinterProxyConfiguration>,
     pub player_count: RwLock<u32>,
+    pub id: RwLock<i32>,
 }
 
 impl SplinterState {
@@ -18,6 +19,7 @@ impl SplinterState {
         Arc::new(SplinterState {
             config: RwLock::new(config),
             player_count: RwLock::new(0),
+            id: RwLock::new(0),
         })
     }
 }


### PR DESCRIPTION
Chat works, but a bunch of stuff had to be refactored for it to work.

- Client states, client state list in proxy state
- Client state has mutex to server writer
- Cross-thread messaging converted to two reading threads writing to the client's mutex
- Proxy generates UUID for client, since chat requires UUIDs
- `PacketMapFn` argument types are now `&SplinterClient` `&SplinterState` `&RawPacketLatest` and returns a bool, whether or not to continue relaying the message (No more `MapAction`).