### PR TITLE
Id getter, move get_config, main.rs connection code to connection.rs, split packet_map into server and client halves

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -22,10 +22,10 @@ use crate::{
 };
 
 /// Initializes chat handling
-pub fn init(map: &mut PacketMap) {
-    map.insert(
+pub fn init(state: &mut SplinterState) {
+    state.client_packet_map.insert(
         PacketLatestKind::PlayClientChatMessage,
-        Box::new(|client, state: &SplinterState, raw_packet| {
+        Box::new(|client, state, raw_packet| {
             match raw_packet.deserialize() {
                 Ok(packet) => {
                     if let PacketLatest::PlayClientChatMessage(data) = packet {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -32,7 +32,12 @@ pub fn init(map: &mut PacketMap) {
                         info!("{}", data.message);
                         match data.message.get(..1) {
                             Some("/") => {
-                                if let Err(e) = client.servers.read().unwrap()[0] // TODO: select the correct server
+                                if let Err(e) = client
+                                    .servers
+                                    .read()
+                                    .unwrap()
+                                    .get(&0)
+                                    .unwrap() // TODO: select the correct server
                                     .writer
                                     .lock()
                                     .unwrap()
@@ -50,7 +55,7 @@ pub fn init(map: &mut PacketMap) {
                             }
                             _ => {
                                 let message = format!("{}: {}", client.name, data.message);
-                                for (id, target) in state.players.read().unwrap().iter() {
+                                for (_id, target) in state.players.read().unwrap().iter() {
                                     if let Err(e) = target.writer.lock().unwrap().write_packet(
                                         PacketLatest::PlayServerChatMessage(
                                             PlayServerChatMessageSpec {
@@ -64,8 +69,8 @@ pub fn init(map: &mut PacketMap) {
                                         ),
                                     ) {
                                         error!(
-                                            "Failed to send chat message from {} to {}",
-                                            client.name, target.name
+                                            "Failed to send chat message from {} to {}: {}",
+                                            client.name, target.name, e
                                         );
                                     }
                                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ use serde::{
     Serialize,
 };
 
+use crate::state::SplinterState;
+
 /// Structure containing the configuration of the proxy
 ///
 /// A version with defaults can be obtained using this struct's [`Default`] implementation
@@ -163,9 +165,8 @@ impl SplinterProxyConfiguration {
     }
 
     /// Create the server status based on the proxy configuration
-    ///
-    /// `total_players` [`None`] will default to `0` the player count is specified with [`Some`]
-    pub fn server_status(&self, total_players: Option<u32>) -> StatusSpec {
+    pub fn server_status(&self, state: &SplinterState) -> StatusSpec {
+        let total_players = state.players.read().unwrap().len();
         StatusSpec {
             version: self
                 .version
@@ -175,10 +176,8 @@ impl SplinterProxyConfiguration {
                     protocol: *protocol,
                 }),
             players: StatusPlayersSpec {
-                max: self
-                    .max_players
-                    .unwrap_or_else(|| total_players.unwrap_or(0) + 1) as i32,
-                online: total_players.unwrap_or(0) as i32,
+                max: self.max_players.unwrap_or_else(|| total_players as u32 + 1) as i32,
+                online: total_players as i32,
                 sample: self
                     .status
                     .player_sample
@@ -192,9 +191,18 @@ impl SplinterProxyConfiguration {
                             })
                             .collect::<Vec<StatusPlayerSampleSpec>>()
                     })
-                    .unwrap_or_else(
-                        || vec![], // should put the actual players of the server here
-                    ),
+                    .unwrap_or_else(|| {
+                        state
+                            .players
+                            .read()
+                            .unwrap()
+                            .iter()
+                            .map(|(_id, client)| StatusPlayerSampleSpec {
+                                name: client.name.clone(),
+                                id: client.uuid,
+                            })
+                            .collect::<Vec<StatusPlayerSampleSpec>>()
+                    }),
             },
             description: Chat::Text(TextComponent {
                 text: self.status.motd.clone(),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,16 +1,25 @@
 use std::{
-    net::SocketAddr,
+    collections::HashMap,
+    net::{
+        SocketAddr,
+        TcpListener,
+        ToSocketAddrs,
+    },
     sync::{
         mpsc::{
             Receiver,
             Sender,
         },
         Arc,
+        Mutex,
         RwLock,
     },
+    thread,
 };
 
 use craftio_rs::{
+    CraftConnection,
+    CraftIo,
     CraftSyncReader,
     CraftSyncWriter,
     CraftTcpConnection,
@@ -22,10 +31,18 @@ use mcproto_rs::{
         Id,
         PacketDirection,
         RawPacket,
+        State,
     },
+    uuid::UUID4,
     v1_16_3::{
+        HandshakeNextState,
+        HandshakeSpec,
+        LoginSetCompressionSpec,
+        LoginStartSpec,
         Packet753 as PacketLatest,
         RawPacket753 as RawPacketLatest,
+        StatusPongSpec,
+        StatusResponseSpec,
     },
 };
 
@@ -34,9 +51,346 @@ use crate::{
     mapping::PacketMap,
     state::{
         SplinterClient,
+        SplinterServerConnection,
         SplinterState,
     },
 };
+
+/// Listens for incoming connections
+///
+/// This hands control of new connections to a new thread running [`await_handshake`].
+pub fn listen_for_clients(state: Arc<SplinterState>) {
+    let listener = match TcpListener::bind(&state.config.read().unwrap().bind_address) {
+        Err(e) => {
+            return error!(
+                "Failed to bind TCP listener to {}: {}",
+                &state.config.read().unwrap().bind_address,
+                e
+            )
+        }
+        Ok(listener) => listener,
+    };
+    for stream in listener.incoming() {
+        let stream = match stream {
+            Ok(stream) => stream,
+            Err(e) => {
+                error!("Error when receiving incoming stream: {}", e);
+                continue;
+            }
+        };
+
+        let sock_addr = stream.peer_addr().unwrap();
+        let craft_conn = match CraftConnection::from_std_with_state(
+            stream,
+            PacketDirection::ServerBound,
+            State::Handshaking,
+        ) {
+            Ok(conn) => conn,
+            Err(e) => {
+                error!("Failed to wrap TCP stream {}: {}", sock_addr, e);
+                continue;
+            }
+        };
+        info!("Got connection from {}", sock_addr);
+        let cloned_state = Arc::clone(&state);
+        thread::spawn(move || await_handshake(cloned_state, craft_conn, sock_addr));
+    }
+}
+
+/// Waits for a handshake from the provided connection
+///
+/// Branches into [`handle_status`] and [`handle_login`] depending on the handshake's next state.
+pub fn await_handshake(
+    state: Arc<SplinterState>,
+    mut craft_conn: CraftTcpConnection,
+    sock_addr: SocketAddr,
+) {
+    match craft_conn.read_raw_packet::<RawPacketLatest>() {
+        Ok(Some(RawPacketLatest::Handshake(handshake_body))) => {
+            match handshake_body.deserialize() {
+                Ok(handshake) => {
+                    debug!(
+                        "received handshake from {}: ver {}, server {}:{}, next: {:?}",
+                        sock_addr,
+                        handshake.version,
+                        handshake.server_address,
+                        handshake.server_port,
+                        handshake.next_state
+                    );
+                    match handshake.next_state {
+                        HandshakeNextState::Status => handle_status(state, craft_conn, sock_addr),
+                        HandshakeNextState::Login => handle_login(state, craft_conn, sock_addr),
+                    }
+                }
+                Err(e) => {
+                    error!("Error parsing handshake packet from {}: {}", sock_addr, e)
+                }
+            }
+        }
+        Ok(Some(other)) => {
+            error!("Unexpected packet from {}: {:?}", sock_addr, other)
+        }
+        Ok(None) => info!("Connection with {} closed before handshake", sock_addr),
+        Err(e) => {
+            error!("Error reading packet from {}: {}", sock_addr, e)
+        }
+    }
+}
+
+/// Responds to connection with status response and waits for pings
+pub fn handle_status(
+    state: Arc<SplinterState>,
+    mut craft_conn: CraftTcpConnection,
+    sock_addr: SocketAddr,
+) {
+    craft_conn.set_state(State::Status);
+    if let Err(e) = craft_conn.write_packet(PacketLatest::StatusResponse(StatusResponseSpec {
+        response: state.config.read().unwrap().server_status(&*state),
+    })) {
+        return error!("Failed to write status response to {}: {}", sock_addr, e);
+    }
+
+    loop {
+        match craft_conn.read_raw_packet::<RawPacketLatest>() {
+            Ok(Some(RawPacketLatest::StatusPing(body))) => match body.deserialize() {
+                Ok(ping) => {
+                    debug!("Got ping {} from {}", ping.payload, sock_addr);
+                    if let Err(e) =
+                        craft_conn.write_packet(PacketLatest::StatusPong(StatusPongSpec {
+                            payload: ping.payload,
+                        }))
+                    {
+                        return error!("Failed to write pong to client {}: {}", sock_addr, e);
+                    }
+                }
+                Err(e) => {
+                    error!("Error parsing ping packet from {}: {}", sock_addr, e)
+                }
+            },
+            Ok(Some(other)) => {
+                error!("Unexpected packet from {}: {:?}", sock_addr, other)
+            }
+            Ok(None) => {
+                info!("Connection with {} closed", sock_addr);
+                break;
+            }
+            Err(e) => error!("Error reading packet from {}: {}", sock_addr, e),
+        }
+    }
+}
+
+/// Handles login sequence between server and client
+///
+/// After login, packets can be inspected and relayed.
+pub fn handle_login(
+    state: Arc<SplinterState>,
+    mut client_conn: CraftTcpConnection,
+    client_addr: SocketAddr,
+) {
+    client_conn.set_state(State::Login);
+    let logindata;
+    loop {
+        match client_conn.read_raw_packet::<RawPacketLatest>() {
+            Ok(Some(RawPacketLatest::LoginStart(body))) => match body.deserialize() {
+                Ok(data) => {
+                    logindata = data;
+                    break;
+                }
+                Err(e) => {
+                    return error!(
+                        "Error parsing login start packet from {}: {}",
+                        client_addr, e
+                    )
+                }
+            },
+            Ok(Some(RawPacketLatest::Handshake(body))) => {
+                warn!("Got a second handshake? {:?}", body.deserialize().unwrap());
+            }
+            Ok(Some(other)) => {
+                return error!(
+                    "Expected a login packet from {}, got {:?}",
+                    client_addr, other
+                )
+            }
+            Ok(None) => {
+                return info!(
+                    "Connection to {} closed before login packet is received",
+                    client_addr
+                )
+            }
+            Err(e) => return error!("Error reading packet from {}: {}", client_addr, e),
+        };
+    }
+    let name = logindata.name;
+    info!("\"{}\" is attempting to login from {}", name, client_addr);
+    debug!("Connecting \"{}\" to server", name);
+    let server_addr = state
+        .config
+        .read()
+        .unwrap()
+        .server_address
+        .as_str()
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap(); // yea
+    let mut server_conn = match CraftTcpConnection::connect_server_std(server_addr) {
+        Ok(conn) => conn,
+        Err(e) => {
+            return error!(
+                "Failed to connect {} to server at {}: {}",
+                name, server_addr, e
+            )
+        }
+    };
+
+    if let Err(e) = server_conn.write_packet(PacketLatest::Handshake(HandshakeSpec {
+        version: state.config.read().unwrap().protocol_version.into(),
+        server_address: format!("{}", server_addr.ip()),
+        server_port: server_addr.port(),
+        next_state: HandshakeNextState::Login,
+    })) {
+        return error!("Failed to write handshake to server {}: {}", server_addr, e);
+    }
+
+    server_conn.set_state(State::Login);
+    if let Err(e) = server_conn.write_packet(PacketLatest::LoginStart(LoginStartSpec {
+        name: name.clone(),
+    })) {
+        return error!(
+            "Failed to write login start to server {}: {}",
+            server_addr, e
+        );
+    }
+    // look for potential compression packet
+    let next_packet = match server_conn.read_raw_packet::<RawPacketLatest>() {
+        Ok(Some(RawPacketLatest::LoginSetCompression(body))) => {
+            let threshold = match body.deserialize() {
+                Ok(LoginSetCompressionSpec {
+                    threshold,
+                }) => i32::from(threshold),
+                Err(e) => {
+                    return error!(
+                        "Failed to deserialize compression set packet for {}: {}",
+                        name, e
+                    )
+                }
+            };
+            debug!(
+                "Got compression setting from server for {}: {}",
+                name, threshold
+            );
+            server_conn.set_compression_threshold(if threshold > 0 {
+                Some(threshold)
+            } else {
+                None
+            });
+            server_conn.read_raw_packet::<RawPacketLatest>()
+        }
+        other => other,
+    };
+    let client_uuid = UUID4::random();
+    let servers_client_uuid;
+    // read login success
+    match next_packet {
+        Ok(Some(RawPacketLatest::LoginSuccess(body))) => {
+            if let Some(threshold) = state.config.read().unwrap().compression_threshold {
+                match client_conn.write_packet(PacketLatest::LoginSetCompression(
+                    LoginSetCompressionSpec {
+                        threshold: threshold.into(),
+                    },
+                )) {
+                    Ok(()) => {
+                        debug!("Sent set compression to {} of {}", name, threshold);
+                        client_conn.set_compression_threshold(
+                            state.config.read().unwrap().compression_threshold,
+                        );
+                    }
+                    Err(e) => {
+                        return error!("Failed to send set compression packet to {}: {}", name, e)
+                    }
+                }
+            }
+            let mut packet = match body.deserialize() {
+                Ok(packet) => packet,
+                Err(e) => return error!("Failed to deserialize login success: {}", e),
+            };
+            servers_client_uuid = packet.uuid;
+            packet.uuid = client_uuid;
+            match client_conn.write_packet(PacketLatest::LoginSuccess(packet)) {
+                Ok(()) => {
+                    debug!("Relaying login packet to server for {}", name)
+                }
+                Err(e) => return error!("Failed to relay login packet to server {}: {}", name, e),
+            }
+            client_conn.set_state(State::Play);
+            server_conn.set_state(State::Play);
+        }
+        Ok(Some(packet)) => {
+            return error!(
+                "Expected a login success packet for {}, got {:?}",
+                name, packet
+            )
+        }
+        Ok(None) => {
+            return info!(
+                "Server connection closed before receiving login packet {}",
+                name
+            )
+        }
+        Err(e) => return error!("Failed to read packet from server for {}: {}", name, e),
+    }
+
+    let (server_reader, server_writer) = server_conn.into_split(); // proxy's connection to the server
+    let (client_reader, client_writer) = client_conn.into_split(); // proxy's connection to the client
+    let splinter_client = SplinterClient {
+        id: state.next_client_id(),
+        name: name,
+        writer: Mutex::new(client_writer),
+        uuid: client_uuid,
+        servers: RwLock::new(HashMap::new()),
+        alive: RwLock::new(true),
+    };
+    // TODO: we'll just grab first available server id for now
+    let server_id = *state.servers.read().unwrap().iter().next().unwrap().0;
+    let server_client_conn = Arc::new(SplinterServerConnection {
+        addr: server_addr,
+        id: server_id,
+        writer: Mutex::new(server_writer),
+        client_uuid: servers_client_uuid,
+    });
+    splinter_client
+        .servers
+        .write()
+        .unwrap()
+        .insert(server_id, Arc::clone(&server_client_conn));
+    let splinter_client = Arc::new(splinter_client);
+    {
+        let mut players = state.players.write().unwrap();
+        players.insert(splinter_client.id, Arc::clone(&splinter_client));
+    }
+    // client reader
+    {
+        let client = Arc::clone(&splinter_client);
+        let client2 = Arc::clone(&splinter_client);
+        let state = Arc::clone(&state);
+        let state2 = Arc::clone(&state);
+        thread::spawn(move || {
+            handle_client_reader(client, state, client_reader);
+            let mut players = state2.players.write().unwrap();
+            players.remove_entry(&client2.id);
+        });
+    }
+
+    // server reader
+    {
+        let client = Arc::clone(&splinter_client);
+        let state = Arc::clone(&state);
+        thread::spawn(move || {
+            handle_server_reader(client, server_client_conn, state, server_reader);
+        });
+    }
+}
 
 /// Handles reading a connection and deciding what to do with data
 ///
@@ -51,39 +405,32 @@ use crate::{
 ///
 /// `direction` is the packet flow, whether packets are coming from server (client bound) or coming
 /// from client (server bound)
-pub fn handle_reader(
+pub fn handle_client_reader(
     client: Arc<SplinterClient>,
     state: Arc<SplinterState>,
-    is_alive: Arc<RwLock<bool>>,
     mut reader: impl CraftSyncReader,
-    packet_map: Arc<PacketMap>,
-    direction: PacketDirection,
 ) {
-    while *is_alive.read().unwrap() {
+    while *client.alive.read().unwrap() {
         match reader.read_raw_packet::<RawPacketLatest>() {
             Ok(Some(raw_packet)) => {
-                if match packet_map.get(&raw_packet.kind()) {
-                    Some(entry) => entry(&*client, &*state, &raw_packet),
+                if match state.client_packet_map.get(&raw_packet.kind()) {
+                    Some(entry) => entry(&client, &state, &raw_packet),
                     None => true,
                 } {
-                    if let Err(e) = match direction {
-                        PacketDirection::ClientBound => {
-                            client.writer.lock().unwrap().write_raw_packet(raw_packet)
-                        }
-                        PacketDirection::ServerBound => client
-                            .servers
-                            .read()
-                            .unwrap()
-                            .get(&0)
-                            .unwrap()
-                            .writer
-                            .lock()
-                            .unwrap()
-                            .write_raw_packet(raw_packet),
-                    } {
+                    if let Err(e) = client
+                        .servers
+                        .read()
+                        .unwrap()
+                        .get(&0)
+                        .unwrap()
+                        .writer
+                        .lock()
+                        .unwrap()
+                        .write_raw_packet(raw_packet)
+                    {
                         error!(
-                            "Failed to send packet for {}: {:?}, {}",
-                            client.name, direction, e
+                            "Failed to relay packet to server for {}: {}",
+                            client.name, e
                         );
                     }
                 }
@@ -96,6 +443,53 @@ pub fn handle_reader(
             }
         }
     }
-    *is_alive.write().unwrap() = false;
-    trace!("reader thread closed for {}", client.name);
+    *client.alive.write().unwrap() = false;
+    trace!("client reader thread closed for {}", client.name);
+}
+
+/// Handles reading a connection and deciding what to do with data
+///
+/// `client` contains the state of the client.
+///
+/// `state` is the state of the proxy.
+///
+/// `is_alive` is a [`Arc`]<[`RwLock`]<[`bool`]>>. The as long as `is_alive` is true, then the reader
+/// will continue reading. The reader can also turn off `is_alive` itself.
+///
+/// `packet_map` is an [`Arc`]<[`PacketMap`]> so that it can correctly determine what to do with certain packets.
+///
+/// `direction` is the packet flow, whether packets are coming from server (client bound) or coming
+/// from client (server bound)
+pub fn handle_server_reader(
+    client: Arc<SplinterClient>,
+    server: Arc<SplinterServerConnection>,
+    state: Arc<SplinterState>,
+    mut reader: impl CraftSyncReader,
+) {
+    while *client.alive.read().unwrap() {
+        match reader.read_raw_packet::<RawPacketLatest>() {
+            Ok(Some(raw_packet)) => {
+                if match state.server_packet_map.get(&raw_packet.kind()) {
+                    Some(entry) => entry(&client, &server, &state, &raw_packet),
+                    None => true,
+                } {
+                    if let Err(e) = client.writer.lock().unwrap().write_raw_packet(raw_packet) {
+                        error!(
+                            "Failed to relay packet to client for {}: {}",
+                            client.name, e
+                        );
+                    }
+                }
+            }
+            Ok(None) => {
+                break;
+            }
+            Err(e) => {
+                error!("Failed to read packet for {}: {}", client.name, e);
+            }
+        }
+    }
+    // TODO: server connection closing should not result in client connection closing
+    *client.alive.write().unwrap() = false;
+    trace!("server reader thread closed for {}", client.name);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(unused_imports)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -9,6 +10,7 @@ use std::{
     collections::HashMap,
     iter::FromIterator,
     net::{
+        SocketAddr,
         TcpListener,
         ToSocketAddrs,
     },
@@ -66,15 +68,11 @@ use simplelog::{
 };
 
 mod connection;
-use crate::connection::{
-    handle_reader,
-    HasCraftConn,
-    SplinterClientConnection,
-    SplinterServerConnection,
-};
+use crate::connection::handle_reader;
 
 mod config;
 use crate::config::{
+    get_config,
     ConfigLoadError,
     ConfigSaveError,
     SplinterProxyConfiguration,
@@ -87,6 +85,7 @@ mod state;
 use crate::state::{
     SplinterClient,
     SplinterServer,
+    SplinterServerConnection,
     SplinterState,
 };
 
@@ -100,69 +99,6 @@ use crate::zoning::{
 
 mod chat;
 use crate::chat::init;
-
-lazy_static! {
-    static ref CONNECTION_ID_COUNT: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
-    static ref SERVER_ID_COUNT: Arc<Mutex<u64>> = Arc::new(Mutex::new(0));
-}
-
-fn get_id(counter: &Mutex<u64>) -> u64 {
-    let mut guard = counter.lock().unwrap();
-    let new_id = *guard;
-    *guard += 1;
-    new_id
-}
-
-/// Loads configuration from the specified .ron file
-///
-/// # Example
-/// ```rust
-/// let config = get_config("./config.ron");
-/// if let Some(threshold) = config.compression_threshold {
-///     info!("compression threshold is {}", threshold);
-/// }
-/// ```
-fn get_config(config_path: &str) -> SplinterProxyConfiguration {
-    let config = match SplinterProxyConfiguration::load(Path::new(config_path)) {
-        Ok(config) => {
-            info!("Config loaded from {}", config_path);
-            config
-        }
-        Err(ConfigLoadError::NoFile) => {
-            warn!(
-                "No config file found at {}. Creating a new one from defaults",
-                config_path
-            );
-            let config = SplinterProxyConfiguration::default();
-            match config.save(Path::new(config_path)) {
-                Ok(()) => {}
-                Err(ConfigSaveError::Create(e)) => {
-                    error!("Failed to create file at {}: {}", config_path, e);
-                }
-                Err(ConfigSaveError::Write(e)) => {
-                    error!("Failed to write to {}: {}", config_path, e);
-                }
-            }
-            config
-        }
-        Err(ConfigLoadError::Io(e)) => {
-            error!(
-                "Failed to read config file at {}: {} Using default settings",
-                config_path, e
-            );
-            SplinterProxyConfiguration::default()
-        }
-        Err(ConfigLoadError::De(e)) => {
-            error!(
-                "Failure to deserialize config file at {}: {}. Using default settings",
-                config_path, e
-            );
-            SplinterProxyConfiguration::default()
-        }
-    };
-
-    config
-}
 
 fn main() {
     CombinedLogger::init(vec![TermLogger::new(
@@ -234,8 +170,29 @@ fn main() {
     // );
 
     let packet_map: Arc<PacketMap> = Arc::new(map);
-    let state = SplinterState::new(get_config("./config.ron"));
-    listen_for_clients(state, packet_map);
+    let state = SplinterState {
+        config: RwLock::new(get_config("./config.ron")),
+        players: RwLock::new(HashMap::new()),
+        servers: RwLock::new(HashMap::new()),
+    };
+    // single server specific, temporary
+    let server_id = state.next_server_id();
+    state.servers.write().unwrap().insert(
+        server_id,
+        SplinterServer {
+            id: server_id,
+            addr: state
+                .config
+                .read()
+                .unwrap()
+                .server_address
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        },
+    );
+    listen_for_clients(Arc::new(state), packet_map);
 }
 
 /// Listens for incoming connections
@@ -273,16 +230,10 @@ fn listen_for_clients(state: Arc<SplinterState>, packet_map: Arc<PacketMap>) {
                 continue;
             }
         };
-
-        let conn = SplinterClientConnection {
-            craft_conn: craft_conn,
-            sock_addr: sock_addr,
-        };
-
         info!("Got connection from {}", sock_addr);
-        let packet_map = packet_map.clone();
-        let cloned_state = state.clone();
-        thread::spawn(move || await_handshake(cloned_state, conn, packet_map));
+        let packet_map = Arc::clone(&packet_map);
+        let cloned_state = Arc::clone(&state);
+        thread::spawn(move || await_handshake(cloned_state, craft_conn, sock_addr, packet_map));
     }
 }
 
@@ -291,76 +242,86 @@ fn listen_for_clients(state: Arc<SplinterState>, packet_map: Arc<PacketMap>) {
 /// Branches into [`handle_status`] and [`handle_login`] depending on the handshake's next state.
 fn await_handshake(
     state: Arc<SplinterState>,
-    mut conn: SplinterClientConnection,
+    mut craft_conn: CraftTcpConnection,
+    sock_addr: SocketAddr,
     packet_map: Arc<PacketMap>,
 ) {
-    match conn.craft_conn.read_raw_packet::<RawPacketLatest>() {
+    match craft_conn.read_raw_packet::<RawPacketLatest>() {
         Ok(Some(RawPacketLatest::Handshake(handshake_body))) => {
             match handshake_body.deserialize() {
                 Ok(handshake) => {
                     debug!(
                         "received handshake from {}: ver {}, server {}:{}, next: {:?}",
-                        conn.sock_addr,
+                        sock_addr,
                         handshake.version,
                         handshake.server_address,
                         handshake.server_port,
                         handshake.next_state
                     );
                     match handshake.next_state {
-                        HandshakeNextState::Status => handle_status(state, conn),
-                        HandshakeNextState::Login => handle_login(state, conn, packet_map),
+                        HandshakeNextState::Status => handle_status(state, craft_conn, sock_addr),
+                        HandshakeNextState::Login => {
+                            handle_login(state, craft_conn, sock_addr, packet_map)
+                        }
                     }
                 }
                 Err(e) => {
-                    error!(
-                        "Error parsing handshake packet from {}: {}",
-                        conn.sock_addr, e
-                    )
+                    error!("Error parsing handshake packet from {}: {}", sock_addr, e)
                 }
             }
         }
         Ok(Some(other)) => {
-            error!("Unexpected packet from {}: {:?}", conn.sock_addr, other)
+            error!("Unexpected packet from {}: {:?}", sock_addr, other)
         }
-        Ok(None) => info!("Connection with {} closed before handshake", conn.sock_addr),
+        Ok(None) => info!("Connection with {} closed before handshake", sock_addr),
         Err(e) => {
-            error!("Error reading packet from {}: {}", conn.sock_addr, e)
+            error!("Error reading packet from {}: {}", sock_addr, e)
         }
     }
 }
 
 /// Responds to connection with status response and waits for pings
-fn handle_status(state: Arc<SplinterState>, mut conn: SplinterClientConnection) {
-    conn.craft_conn.set_state(State::Status);
-    conn.write_packet(PacketLatest::StatusResponse(StatusResponseSpec {
+fn handle_status(
+    state: Arc<SplinterState>,
+    mut craft_conn: CraftTcpConnection,
+    sock_addr: SocketAddr,
+) {
+    craft_conn.set_state(State::Status);
+    if let Err(e) = craft_conn.write_packet(PacketLatest::StatusResponse(StatusResponseSpec {
         response: state
             .config
             .read()
             .unwrap()
             .server_status(Some(state.players.read().unwrap().len() as u32)),
-    }));
+    })) {
+        return error!("Failed to write status response to {}: {}", sock_addr, e);
+    }
 
     loop {
-        match conn.craft_conn.read_raw_packet::<RawPacketLatest>() {
+        match craft_conn.read_raw_packet::<RawPacketLatest>() {
             Ok(Some(RawPacketLatest::StatusPing(body))) => match body.deserialize() {
                 Ok(ping) => {
-                    debug!("Got ping {} from {}", ping.payload, conn.sock_addr);
-                    conn.write_packet(PacketLatest::StatusPong(StatusPongSpec {
-                        payload: ping.payload,
-                    }));
+                    debug!("Got ping {} from {}", ping.payload, sock_addr);
+                    if let Err(e) =
+                        craft_conn.write_packet(PacketLatest::StatusPong(StatusPongSpec {
+                            payload: ping.payload,
+                        }))
+                    {
+                        return error!("Failed to write pong to client {}: {}", sock_addr, e);
+                    }
                 }
                 Err(e) => {
-                    error!("Error parsing ping packet from {}: {}", conn.sock_addr, e)
+                    error!("Error parsing ping packet from {}: {}", sock_addr, e)
                 }
             },
             Ok(Some(other)) => {
-                error!("Unexpected packet from {}: {:?}", conn.sock_addr, other)
+                error!("Unexpected packet from {}: {:?}", sock_addr, other)
             }
             Ok(None) => {
-                info!("Connection with {} closed", conn.sock_addr);
+                info!("Connection with {} closed", sock_addr);
                 break;
             }
-            Err(e) => error!("Error reading packet from {}: {}", conn.sock_addr, e),
+            Err(e) => error!("Error reading packet from {}: {}", sock_addr, e),
         }
     }
 }
@@ -370,13 +331,14 @@ fn handle_status(state: Arc<SplinterState>, mut conn: SplinterClientConnection) 
 /// After login, packets can be inspected and relayed.
 fn handle_login(
     state: Arc<SplinterState>,
-    mut client: SplinterClientConnection,
+    mut client_conn: CraftTcpConnection,
+    client_addr: SocketAddr,
     packet_map: Arc<PacketMap>,
 ) {
-    client.craft_conn.set_state(State::Login);
+    client_conn.set_state(State::Login);
     let logindata;
     loop {
-        match client.craft_conn.read_raw_packet::<RawPacketLatest>() {
+        match client_conn.read_raw_packet::<RawPacketLatest>() {
             Ok(Some(RawPacketLatest::LoginStart(body))) => match body.deserialize() {
                 Ok(data) => {
                     logindata = data;
@@ -385,7 +347,7 @@ fn handle_login(
                 Err(e) => {
                     return error!(
                         "Error parsing login start packet from {}: {}",
-                        client.sock_addr, e
+                        client_addr, e
                     )
                 }
             },
@@ -395,23 +357,20 @@ fn handle_login(
             Ok(Some(other)) => {
                 return error!(
                     "Expected a login packet from {}, got {:?}",
-                    client.sock_addr, other
+                    client_addr, other
                 )
             }
             Ok(None) => {
                 return info!(
                     "Connection to {} closed before login packet is received",
-                    client.sock_addr
+                    client_addr
                 )
             }
-            Err(e) => return error!("Error reading packet from {}: {}", client.sock_addr, e),
+            Err(e) => return error!("Error reading packet from {}: {}", client_addr, e),
         };
     }
     let name = logindata.name;
-    info!(
-        "\"{}\" is attempting to login from {}",
-        name, client.sock_addr
-    );
+    info!("\"{}\" is attempting to login from {}", name, client_addr);
     debug!("Connecting \"{}\" to server", name);
     let server_addr = state
         .config
@@ -423,7 +382,7 @@ fn handle_login(
         .unwrap()
         .next()
         .unwrap(); // yea
-    let craft_conn = match CraftTcpConnection::connect_server_std(server_addr) {
+    let mut server_conn = match CraftTcpConnection::connect_server_std(server_addr) {
         Ok(conn) => conn,
         Err(e) => {
             return error!(
@@ -432,24 +391,27 @@ fn handle_login(
             )
         }
     };
-    let mut server = SplinterServerConnection {
-        craft_conn: craft_conn,
-        sock_addr: server_addr,
-    };
 
-    server.write_packet(PacketLatest::Handshake(HandshakeSpec {
+    if let Err(e) = server_conn.write_packet(PacketLatest::Handshake(HandshakeSpec {
         version: state.config.read().unwrap().protocol_version.into(),
         server_address: format!("{}", server_addr.ip()),
         server_port: server_addr.port(),
         next_state: HandshakeNextState::Login,
-    }));
+    })) {
+        return error!("Failed to write handshake to server {}: {}", server_addr, e);
+    }
 
-    server.craft_conn.set_state(State::Login);
-    server.write_packet(PacketLatest::LoginStart(LoginStartSpec {
+    server_conn.set_state(State::Login);
+    if let Err(e) = server_conn.write_packet(PacketLatest::LoginStart(LoginStartSpec {
         name: name.clone(),
-    }));
+    })) {
+        return error!(
+            "Failed to write login start to server {}: {}",
+            server_addr, e
+        );
+    }
     // look for potential compression packet
-    let next_packet = match server.craft_conn.read_raw_packet::<RawPacketLatest>() {
+    let next_packet = match server_conn.read_raw_packet::<RawPacketLatest>() {
         Ok(Some(RawPacketLatest::LoginSetCompression(body))) => {
             let threshold = match body.deserialize() {
                 Ok(LoginSetCompressionSpec {
@@ -466,10 +428,12 @@ fn handle_login(
                 "Got compression setting from server for {}: {}",
                 name, threshold
             );
-            server
-                .craft_conn
-                .set_compression_threshold(if threshold > 0 { Some(threshold) } else { None });
-            server.craft_conn.read_raw_packet::<RawPacketLatest>()
+            server_conn.set_compression_threshold(if threshold > 0 {
+                Some(threshold)
+            } else {
+                None
+            });
+            server_conn.read_raw_packet::<RawPacketLatest>()
         }
         other => other,
     };
@@ -479,14 +443,14 @@ fn handle_login(
     match next_packet {
         Ok(Some(RawPacketLatest::LoginSuccess(body))) => {
             if let Some(threshold) = state.config.read().unwrap().compression_threshold {
-                match client
-                    .craft_conn
-                    .write_packet(PacketLatest::LoginSetCompression(LoginSetCompressionSpec {
+                match client_conn.write_packet(PacketLatest::LoginSetCompression(
+                    LoginSetCompressionSpec {
                         threshold: threshold.into(),
-                    })) {
+                    },
+                )) {
                     Ok(()) => {
                         debug!("Sent set compression to {} of {}", name, threshold);
-                        client.craft_conn.set_compression_threshold(
+                        client_conn.set_compression_threshold(
                             state.config.read().unwrap().compression_threshold,
                         );
                     }
@@ -501,17 +465,14 @@ fn handle_login(
             };
             servers_client_uuid = packet.uuid;
             packet.uuid = client_uuid;
-            match client
-                .craft_conn
-                .write_packet(PacketLatest::LoginSuccess(packet))
-            {
+            match client_conn.write_packet(PacketLatest::LoginSuccess(packet)) {
                 Ok(()) => {
                     debug!("Relaying login packet to server for {}", name)
                 }
                 Err(e) => return error!("Failed to relay login packet to server {}: {}", name, e),
             }
-            client.craft_conn.set_state(State::Play);
-            server.craft_conn.set_state(State::Play);
+            client_conn.set_state(State::Play);
+            server_conn.set_state(State::Play);
         }
         Ok(Some(packet)) => {
             return error!(
@@ -528,31 +489,38 @@ fn handle_login(
         Err(e) => return error!("Failed to read packet from server for {}: {}", name, e),
     }
 
-    let (server_reader, server_writer) = server.craft_conn.into_split(); // proxy's connection to the server
-    let (client_reader, client_writer) = client.craft_conn.into_split(); // proxy's connection to the client
-    let client_data = Arc::new(SplinterClient {
-        id: get_id(&*CONNECTION_ID_COUNT),
+    let (server_reader, server_writer) = server_conn.into_split(); // proxy's connection to the server
+    let (client_reader, client_writer) = client_conn.into_split(); // proxy's connection to the client
+    let splinter_client = SplinterClient {
+        id: state.next_client_id(),
         name: name,
         writer: Mutex::new(client_writer),
         uuid: client_uuid,
-        servers: RwLock::new(vec![SplinterServer {
-            addr: server.sock_addr,
-            id: get_id(&*SERVER_ID_COUNT),
+        servers: RwLock::new(HashMap::new()),
+    };
+    // TODO: we'll just grab first available server id for now
+    let server_id = *state.servers.read().unwrap().iter().next().unwrap().0;
+    splinter_client.servers.write().unwrap().insert(
+        server_id,
+        SplinterServerConnection {
+            addr: server_addr,
+            id: server_id,
             writer: Mutex::new(server_writer),
             client_uuid: servers_client_uuid,
-        }]),
-    });
+        },
+    );
+    let splinter_client = Arc::new(splinter_client);
     {
         let mut players = state.players.write().unwrap();
-        players.insert(client_data.id, client_data.clone());
+        players.insert(splinter_client.id, Arc::clone(&splinter_client));
     }
     let is_alive_arc = Arc::new(RwLock::new(true));
     // client reader
     {
-        let client = client_data.clone();
-        let state = state.clone();
-        let packet_map = packet_map.clone();
-        let is_alive_arc = is_alive_arc.clone();
+        let client = Arc::clone(&splinter_client);
+        let state = Arc::clone(&state);
+        let packet_map = Arc::clone(&packet_map);
+        let is_alive_arc = Arc::clone(&is_alive_arc);
         thread::spawn(move || {
             handle_reader(
                 client,
@@ -567,11 +535,11 @@ fn handle_login(
 
     // server reader
     {
-        let client = client_data.clone();
-        let state = state.clone();
-        let state2 = state.clone();
-        let packet_map = packet_map.clone();
-        let is_alive_arc = is_alive_arc.clone();
+        let client = Arc::clone(&splinter_client);
+        let state = Arc::clone(&state);
+        let state2 = Arc::clone(&state);
+        let packet_map = Arc::clone(&packet_map);
+        let is_alive_arc = Arc::clone(&is_alive_arc);
         thread::spawn(move || {
             handle_reader(
                 client,
@@ -583,7 +551,7 @@ fn handle_login(
             );
             {
                 let mut players = state2.players.write().unwrap();
-                players.remove_entry(&client_data.id);
+                players.remove_entry(&splinter_client.id);
             }
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,58 +6,10 @@ extern crate log;
 extern crate simplelog;
 
 use std::{
-    self,
-    collections::HashMap,
-    iter::FromIterator,
-    net::{
-        SocketAddr,
-        TcpListener,
-        ToSocketAddrs,
-    },
-    path::Path,
-    sync::{
-        mpsc::{
-            self,
-            Receiver,
-            Sender,
-        },
-        Arc,
-        Mutex,
-        RwLock,
-    },
-    thread,
+    net::ToSocketAddrs,
+    sync::Arc,
 };
 
-use craftio_rs::{
-    CraftConnection,
-    CraftIo,
-    CraftSyncReader,
-    CraftSyncWriter,
-    CraftTcpConnection,
-};
-use mcproto_rs::{
-    protocol::{
-        HasPacketId,
-        Id,
-        PacketDirection,
-        PacketErr,
-        RawPacket,
-        State,
-    },
-    uuid::UUID4,
-    v1_16_3::{
-        HandshakeNextState,
-        HandshakeSpec,
-        LoginSetCompressionSpec,
-        LoginStartSpec,
-        Packet753 as PacketLatest,
-        Packet753Kind as PacketLatestKind,
-        PlayBlockChangeSpec,
-        RawPacket753 as RawPacketLatest,
-        StatusPongSpec,
-        StatusResponseSpec,
-    },
-};
 use simplelog::{
     ColorChoice,
     CombinedLogger,
@@ -67,38 +19,26 @@ use simplelog::{
     TerminalMode,
 };
 
-mod connection;
-use crate::connection::handle_reader;
-
-mod config;
-use crate::config::{
-    get_config,
-    ConfigLoadError,
-    ConfigSaveError,
-    SplinterProxyConfiguration,
-};
-
-mod mapping;
-use crate::mapping::PacketMap;
-
-mod state;
-use crate::state::{
-    SplinterClient,
-    SplinterServer,
-    SplinterServerConnection,
-    SplinterState,
-};
-
-mod zoning;
-use crate::zoning::{
-    BasicZoner,
-    SquareRegion,
-    Vector2,
-    Zoner,
-};
-
 mod chat;
-use crate::chat::init;
+mod config;
+mod connection;
+mod mapping;
+mod state;
+mod zoning;
+use crate::{
+    config::get_config,
+    connection::listen_for_clients,
+    state::{
+        SplinterServer,
+        SplinterState,
+    },
+    zoning::{
+        BasicZoner,
+        SquareRegion,
+        Vector2,
+        Zoner,
+    },
+};
 
 fn main() {
     CombinedLogger::init(vec![TermLogger::new(
@@ -139,9 +79,6 @@ fn main() {
     //     })
     // );
 
-    let mut map: PacketMap = HashMap::new();
-    chat::init(&mut map);
-
     // map.insert(
     //     PacketLatestKind::PlayBlockChange,
     //     Box::new(|state: Arc<SplinterState>, raw_packet: RawPacketLatest| {
@@ -169,12 +106,7 @@ fn main() {
     //     }),
     // );
 
-    let packet_map: Arc<PacketMap> = Arc::new(map);
-    let state = SplinterState {
-        config: RwLock::new(get_config("./config.ron")),
-        players: RwLock::new(HashMap::new()),
-        servers: RwLock::new(HashMap::new()),
-    };
+    let mut state = SplinterState::new(get_config("./config.ron"));
     // single server specific, temporary
     let server_id = state.next_server_id();
     state.servers.write().unwrap().insert(
@@ -192,367 +124,7 @@ fn main() {
                 .unwrap(),
         },
     );
-    listen_for_clients(Arc::new(state), packet_map);
-}
+    chat::init(&mut state);
 
-/// Listens for incoming connections
-///
-/// This hands control of new connections to a new thread running [`await_handshake`].
-fn listen_for_clients(state: Arc<SplinterState>, packet_map: Arc<PacketMap>) {
-    let listener = match TcpListener::bind(&state.config.read().unwrap().bind_address) {
-        Err(e) => {
-            return error!(
-                "Failed to bind TCP listener to {}: {}",
-                &state.config.read().unwrap().bind_address,
-                e
-            )
-        }
-        Ok(listener) => listener,
-    };
-    for stream in listener.incoming() {
-        let stream = match stream {
-            Ok(stream) => stream,
-            Err(e) => {
-                error!("Error when receiving incoming stream: {}", e);
-                continue;
-            }
-        };
-
-        let sock_addr = stream.peer_addr().unwrap();
-        let craft_conn = match CraftConnection::from_std_with_state(
-            stream,
-            PacketDirection::ServerBound,
-            State::Handshaking,
-        ) {
-            Ok(conn) => conn,
-            Err(e) => {
-                error!("Failed to wrap TCP stream {}: {}", sock_addr, e);
-                continue;
-            }
-        };
-        info!("Got connection from {}", sock_addr);
-        let packet_map = Arc::clone(&packet_map);
-        let cloned_state = Arc::clone(&state);
-        thread::spawn(move || await_handshake(cloned_state, craft_conn, sock_addr, packet_map));
-    }
-}
-
-/// Waits for a handshake from the provided connection
-///
-/// Branches into [`handle_status`] and [`handle_login`] depending on the handshake's next state.
-fn await_handshake(
-    state: Arc<SplinterState>,
-    mut craft_conn: CraftTcpConnection,
-    sock_addr: SocketAddr,
-    packet_map: Arc<PacketMap>,
-) {
-    match craft_conn.read_raw_packet::<RawPacketLatest>() {
-        Ok(Some(RawPacketLatest::Handshake(handshake_body))) => {
-            match handshake_body.deserialize() {
-                Ok(handshake) => {
-                    debug!(
-                        "received handshake from {}: ver {}, server {}:{}, next: {:?}",
-                        sock_addr,
-                        handshake.version,
-                        handshake.server_address,
-                        handshake.server_port,
-                        handshake.next_state
-                    );
-                    match handshake.next_state {
-                        HandshakeNextState::Status => handle_status(state, craft_conn, sock_addr),
-                        HandshakeNextState::Login => {
-                            handle_login(state, craft_conn, sock_addr, packet_map)
-                        }
-                    }
-                }
-                Err(e) => {
-                    error!("Error parsing handshake packet from {}: {}", sock_addr, e)
-                }
-            }
-        }
-        Ok(Some(other)) => {
-            error!("Unexpected packet from {}: {:?}", sock_addr, other)
-        }
-        Ok(None) => info!("Connection with {} closed before handshake", sock_addr),
-        Err(e) => {
-            error!("Error reading packet from {}: {}", sock_addr, e)
-        }
-    }
-}
-
-/// Responds to connection with status response and waits for pings
-fn handle_status(
-    state: Arc<SplinterState>,
-    mut craft_conn: CraftTcpConnection,
-    sock_addr: SocketAddr,
-) {
-    craft_conn.set_state(State::Status);
-    if let Err(e) = craft_conn.write_packet(PacketLatest::StatusResponse(StatusResponseSpec {
-        response: state
-            .config
-            .read()
-            .unwrap()
-            .server_status(Some(state.players.read().unwrap().len() as u32)),
-    })) {
-        return error!("Failed to write status response to {}: {}", sock_addr, e);
-    }
-
-    loop {
-        match craft_conn.read_raw_packet::<RawPacketLatest>() {
-            Ok(Some(RawPacketLatest::StatusPing(body))) => match body.deserialize() {
-                Ok(ping) => {
-                    debug!("Got ping {} from {}", ping.payload, sock_addr);
-                    if let Err(e) =
-                        craft_conn.write_packet(PacketLatest::StatusPong(StatusPongSpec {
-                            payload: ping.payload,
-                        }))
-                    {
-                        return error!("Failed to write pong to client {}: {}", sock_addr, e);
-                    }
-                }
-                Err(e) => {
-                    error!("Error parsing ping packet from {}: {}", sock_addr, e)
-                }
-            },
-            Ok(Some(other)) => {
-                error!("Unexpected packet from {}: {:?}", sock_addr, other)
-            }
-            Ok(None) => {
-                info!("Connection with {} closed", sock_addr);
-                break;
-            }
-            Err(e) => error!("Error reading packet from {}: {}", sock_addr, e),
-        }
-    }
-}
-
-/// Handles login sequence between server and client
-///
-/// After login, packets can be inspected and relayed.
-fn handle_login(
-    state: Arc<SplinterState>,
-    mut client_conn: CraftTcpConnection,
-    client_addr: SocketAddr,
-    packet_map: Arc<PacketMap>,
-) {
-    client_conn.set_state(State::Login);
-    let logindata;
-    loop {
-        match client_conn.read_raw_packet::<RawPacketLatest>() {
-            Ok(Some(RawPacketLatest::LoginStart(body))) => match body.deserialize() {
-                Ok(data) => {
-                    logindata = data;
-                    break;
-                }
-                Err(e) => {
-                    return error!(
-                        "Error parsing login start packet from {}: {}",
-                        client_addr, e
-                    )
-                }
-            },
-            Ok(Some(RawPacketLatest::Handshake(body))) => {
-                warn!("Got a second handshake? {:?}", body.deserialize().unwrap());
-            }
-            Ok(Some(other)) => {
-                return error!(
-                    "Expected a login packet from {}, got {:?}",
-                    client_addr, other
-                )
-            }
-            Ok(None) => {
-                return info!(
-                    "Connection to {} closed before login packet is received",
-                    client_addr
-                )
-            }
-            Err(e) => return error!("Error reading packet from {}: {}", client_addr, e),
-        };
-    }
-    let name = logindata.name;
-    info!("\"{}\" is attempting to login from {}", name, client_addr);
-    debug!("Connecting \"{}\" to server", name);
-    let server_addr = state
-        .config
-        .read()
-        .unwrap()
-        .server_address
-        .as_str()
-        .to_socket_addrs()
-        .unwrap()
-        .next()
-        .unwrap(); // yea
-    let mut server_conn = match CraftTcpConnection::connect_server_std(server_addr) {
-        Ok(conn) => conn,
-        Err(e) => {
-            return error!(
-                "Failed to connect {} to server at {}: {}",
-                name, server_addr, e
-            )
-        }
-    };
-
-    if let Err(e) = server_conn.write_packet(PacketLatest::Handshake(HandshakeSpec {
-        version: state.config.read().unwrap().protocol_version.into(),
-        server_address: format!("{}", server_addr.ip()),
-        server_port: server_addr.port(),
-        next_state: HandshakeNextState::Login,
-    })) {
-        return error!("Failed to write handshake to server {}: {}", server_addr, e);
-    }
-
-    server_conn.set_state(State::Login);
-    if let Err(e) = server_conn.write_packet(PacketLatest::LoginStart(LoginStartSpec {
-        name: name.clone(),
-    })) {
-        return error!(
-            "Failed to write login start to server {}: {}",
-            server_addr, e
-        );
-    }
-    // look for potential compression packet
-    let next_packet = match server_conn.read_raw_packet::<RawPacketLatest>() {
-        Ok(Some(RawPacketLatest::LoginSetCompression(body))) => {
-            let threshold = match body.deserialize() {
-                Ok(LoginSetCompressionSpec {
-                    threshold,
-                }) => i32::from(threshold),
-                Err(e) => {
-                    return error!(
-                        "Failed to deserialize compression set packet for {}: {}",
-                        name, e
-                    )
-                }
-            };
-            debug!(
-                "Got compression setting from server for {}: {}",
-                name, threshold
-            );
-            server_conn.set_compression_threshold(if threshold > 0 {
-                Some(threshold)
-            } else {
-                None
-            });
-            server_conn.read_raw_packet::<RawPacketLatest>()
-        }
-        other => other,
-    };
-    let client_uuid = UUID4::random();
-    let servers_client_uuid;
-    // read login success
-    match next_packet {
-        Ok(Some(RawPacketLatest::LoginSuccess(body))) => {
-            if let Some(threshold) = state.config.read().unwrap().compression_threshold {
-                match client_conn.write_packet(PacketLatest::LoginSetCompression(
-                    LoginSetCompressionSpec {
-                        threshold: threshold.into(),
-                    },
-                )) {
-                    Ok(()) => {
-                        debug!("Sent set compression to {} of {}", name, threshold);
-                        client_conn.set_compression_threshold(
-                            state.config.read().unwrap().compression_threshold,
-                        );
-                    }
-                    Err(e) => {
-                        return error!("Failed to send set compression packet to {}: {}", name, e)
-                    }
-                }
-            }
-            let mut packet = match body.deserialize() {
-                Ok(packet) => packet,
-                Err(e) => return error!("Failed to deserialize login success: {}", e),
-            };
-            servers_client_uuid = packet.uuid;
-            packet.uuid = client_uuid;
-            match client_conn.write_packet(PacketLatest::LoginSuccess(packet)) {
-                Ok(()) => {
-                    debug!("Relaying login packet to server for {}", name)
-                }
-                Err(e) => return error!("Failed to relay login packet to server {}: {}", name, e),
-            }
-            client_conn.set_state(State::Play);
-            server_conn.set_state(State::Play);
-        }
-        Ok(Some(packet)) => {
-            return error!(
-                "Expected a login success packet for {}, got {:?}",
-                name, packet
-            )
-        }
-        Ok(None) => {
-            return info!(
-                "Server connection closed before receiving login packet {}",
-                name
-            )
-        }
-        Err(e) => return error!("Failed to read packet from server for {}: {}", name, e),
-    }
-
-    let (server_reader, server_writer) = server_conn.into_split(); // proxy's connection to the server
-    let (client_reader, client_writer) = client_conn.into_split(); // proxy's connection to the client
-    let splinter_client = SplinterClient {
-        id: state.next_client_id(),
-        name: name,
-        writer: Mutex::new(client_writer),
-        uuid: client_uuid,
-        servers: RwLock::new(HashMap::new()),
-    };
-    // TODO: we'll just grab first available server id for now
-    let server_id = *state.servers.read().unwrap().iter().next().unwrap().0;
-    splinter_client.servers.write().unwrap().insert(
-        server_id,
-        SplinterServerConnection {
-            addr: server_addr,
-            id: server_id,
-            writer: Mutex::new(server_writer),
-            client_uuid: servers_client_uuid,
-        },
-    );
-    let splinter_client = Arc::new(splinter_client);
-    {
-        let mut players = state.players.write().unwrap();
-        players.insert(splinter_client.id, Arc::clone(&splinter_client));
-    }
-    let is_alive_arc = Arc::new(RwLock::new(true));
-    // client reader
-    {
-        let client = Arc::clone(&splinter_client);
-        let state = Arc::clone(&state);
-        let packet_map = Arc::clone(&packet_map);
-        let is_alive_arc = Arc::clone(&is_alive_arc);
-        thread::spawn(move || {
-            handle_reader(
-                client,
-                state,
-                is_alive_arc,
-                client_reader,
-                packet_map,
-                PacketDirection::ServerBound,
-            )
-        });
-    }
-
-    // server reader
-    {
-        let client = Arc::clone(&splinter_client);
-        let state = Arc::clone(&state);
-        let state2 = Arc::clone(&state);
-        let packet_map = Arc::clone(&packet_map);
-        let is_alive_arc = Arc::clone(&is_alive_arc);
-        thread::spawn(move || {
-            handle_reader(
-                client,
-                state,
-                is_alive_arc,
-                server_reader,
-                packet_map,
-                PacketDirection::ClientBound,
-            );
-            {
-                let mut players = state2.players.write().unwrap();
-                players.remove_entry(&splinter_client.id);
-            }
-        });
-    }
+    listen_for_clients(Arc::new(state));
 }

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -17,12 +17,25 @@ use mcproto_rs::{
 
 use crate::state::{
     SplinterClient,
+    SplinterServerConnection,
     SplinterState,
 };
 
-/// The function type for packet mapping
-pub type PacketMapFn =
-    Box<dyn Sync + Send + Fn(&SplinterClient, &SplinterState, &RawPacketLatest) -> bool>;
+/// Function for client-proxy packet mapping
+pub type ClientPacketMapFn =
+    Box<dyn Sync + Send + Fn(&Arc<SplinterClient>, &Arc<SplinterState>, &RawPacketLatest) -> bool>;
+
+/// Function for proxy-server packet mapping
+pub type ServerPacketMapFn = Box<
+    dyn Sync
+        + Send
+        + Fn(
+            &Arc<SplinterClient>,
+            &Arc<SplinterServerConnection>,
+            &Arc<SplinterState>,
+            &RawPacketLatest,
+        ) -> bool,
+>;
 
 /// Packet map type
-pub type PacketMap = HashMap<PacketLatestKind, PacketMapFn>;
+pub type PacketMap<T> = HashMap<PacketLatestKind, T>;


### PR DESCRIPTION
Several things in here. Didn't want to submit multiple pull requests ex. pull request for each thing here, but let me know if that should change.

- Client's server connection list changed to a hashmap of id-server pairs
- Removed `SplinterClientConnection`, `SplinterServerConnection`, and `EitherPacket` in connection.rs
- Added server and client new id discovery function dependent on existing ids ( at the moment O(n) where n is client or server count)
- Changed any Arc `.clone` to `Arc::clone(&...)` to avoid ambiguity between the Arc's clone and the underlying type's clone from automatic dereferencing.
- Moved `get_config` to config.rs
- Split `packet_map` into proxy-server and client-proxy halves since packets from the server may need extra information about the server they came from. Also moved into `SplinterState`
- Move `is_alive` into `SplinterClient`
- Move connection functions in main.rs to connection.rs
- Status can now include player list