### PR TITLE
Changed protocol config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ Build and run through `cargo run`
 
 ### Setting up Minecraft server
 
-Grab a 1.16.3 server from [Spigot BuildTools](https://www.spigotmc.org/wiki/buildtools) or [Paper](https://papermc.io/downloads) ([Paper Server Download](https://papermc.io/api/v1/paper/1.16.3/latest/download)).
+Grab a 1.16.5 server from [Spigot BuildTools](https://www.spigotmc.org/wiki/buildtools) or [Paper](https://papermc.io/downloads).
 
 There are some required settings in server.properties:
 
-- `server-port=25400` Server port can be changed within the source code of the proxy.
-- `network-compression-threshold=-1` to disable compression, as the proxy does not support it at the moment.
+- `server-port=25400` Server port can be changed within the config file of the proxy.
 - `online-mode=false` to disable authentication, as authentication will be done either in the proxy or something on top of it like BungeeCord.
 
 Then you can run the server with `java -jar [server jar name].jar --nogui` or run it as a normal application.
 
 ### Joining the proxy
 
-Join with a 1.16.3 Minecraft client. If you're running the proxy on the same device you're playing from, then you can connect to `localhost:25565`.
+Join with a 1.16.5 Minecraft client. If you're running the proxy on the same device you're playing from, then you can connect to `localhost:25565`.
 
 ## Contributing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub struct SplinterProxyConfiguration {
 
     /// [`Some`] tuple of the version name and protocol version number or [`None`] for unspecified
     ///
-    /// `Some(("1.16.3", 754))` by default
+    /// `Some(("1.16.5", 754))` by default
     pub version: Option<(String, i32)>,
 
     /// The server address to proxy to
@@ -104,7 +104,7 @@ impl Default for SplinterProxyConfiguration {
     fn default() -> Self {
         SplinterProxyConfiguration {
             protocol_version: 754,
-            version: Some(("Splinter 1.16.3".into(), 754)),
+            version: Some(("Splinter 1.16.5".into(), 754)),
             server_address: "127.0.0.1:25400".into(),
             bind_address: "127.0.0.1:25565".into(),
             max_players: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub struct SplinterProxyConfiguration {
 
     /// [`Some`] tuple of the version name and protocol version number or [`None`] for unspecified
     ///
-    /// `Some(("1.16.3", 753))` by default
+    /// `Some(("1.16.3", 754))` by default
     pub version: Option<(String, i32)>,
 
     /// The server address to proxy to
@@ -103,8 +103,8 @@ pub struct SplinterProxyStatus {
 impl Default for SplinterProxyConfiguration {
     fn default() -> Self {
         SplinterProxyConfiguration {
-            protocol_version: 753,
-            version: Some(("Splinter 1.16.3".into(), 753)),
+            protocol_version: 754,
+            version: Some(("Splinter 1.16.3".into(), 754)),
             server_address: "127.0.0.1:25400".into(),
             bind_address: "127.0.0.1:25565".into(),
             max_players: None,


### PR DESCRIPTION
Updated protocol version from 753 to 754 in config defaults and updated README to reflect change in usage. 1.16.5 can and should now be used.