### PR TITLE
Send player's packets to dummies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 [[package]]
 name = "mcproto-rs"
 version = "0.2.0"
-source = "git+https://github.com/regenerativep/mcproto-rs?rev=563d176b597215d9dd5f939a6a15b697d9888935#563d176b597215d9dd5f939a6a15b697d9888935"
+source = "git+https://github.com/regenerativep/mcproto-rs?rev=7cc3a46ab0c89f13829e2345242f264f8a937471#7cc3a46ab0c89f13829e2345242f264f8a937471"
 dependencies = [
  "base64 0.12.3",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mcproto-rs = { git = "https://github.com/regenerativep/mcproto-rs", rev = "563d176b597215d9dd5f939a6a15b697d9888935" }
+mcproto-rs = { git = "https://github.com/regenerativep/mcproto-rs", rev = "7cc3a46ab0c89f13829e2345242f264f8a937471" }
 #mcproto-rs = { path = "../mcproto-rs" }
 craftio-rs = { version = "0.1.0", features = ["compression"] }
 rand = "0.8.3"
@@ -28,5 +28,5 @@ futures-lite = "1.12.0"
 arc-swap = "1.3.0"
 
 [patch.crates-io]
-mcproto-rs = { git = "https://github.com/regenerativep/mcproto-rs", rev = "563d176b597215d9dd5f939a6a15b697d9888935" }
+mcproto-rs = { git = "https://github.com/regenerativep/mcproto-rs", rev = "7cc3a46ab0c89f13829e2345242f264f8a937471" }
 #mcproto-rs = { path = "../mcproto-rs" }

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::Ordering,
+    Arc,
+};
 
 use crate::{
     commands::{
@@ -24,7 +27,7 @@ inventory::submit! {
                 }
             }
             info!("Shutting down");
-            proxy.alive.store(Arc::new(false));
+            proxy.alive.store(false, Ordering::Relaxed);
             Ok(())
         }),
     }

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -30,6 +30,9 @@ inventory::submit! {
                 "disconnect" => {
                     smol::block_on(client.disconnect_dummy(target_id))?;
                 },
+                "list" => {
+                    info!("Connected dummies: {}", client.dummy_servers.load().iter().map(|(id, _)| format!("{}", id)).reduce(|a, b| format!("{}, {}", a, b)).unwrap_or_else(|| String::from("None")));
+                },
                 _ => bail!("Unknown subcommand"),
             }
             Ok(())

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,13 +1,15 @@
-use mcproto_rs::protocol::{
-    HasPacketKind,
-    PacketErr,
-    RawPacket,
-};
-
-use crate::current::proto::{
-    Packet756 as PacketLatest,
-    Packet756Kind as PacketLatestKind,
-    RawPacket756 as RawPacketLatest,
+use crate::current::{
+    proto::{
+        Packet756 as PacketLatest,
+        Packet756Kind as PacketLatestKind,
+        RawPacket756 as RawPacketLatest,
+    },
+    protocol::{
+        HasPacketId,
+        HasPacketKind,
+        PacketErr,
+        RawPacket,
+    },
 };
 
 /// A packet that is lazily deserialized when the deserialized packet is accessed
@@ -67,6 +69,17 @@ impl<'a> LazyDeserializedPacket<'a> {
             raw_packet.kind()
         } else {
             self.de_packet.as_ref().unwrap().as_ref().unwrap().kind()
+        }
+    }
+}
+impl<'a> Clone for LazyDeserializedPacket<'a> {
+    fn clone(&self) -> LazyDeserializedPacket<'a> {
+        Self {
+            raw_packet: self
+                .raw_packet
+                .as_ref()
+                .map(|raw| RawPacketLatest::create(raw.id(), raw.data()).unwrap()),
+            de_packet: self.de_packet.clone(),
         }
     }
 }

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -17,8 +17,10 @@ use crate::{
     current::{
         proto::PlayClientKeepAliveSpec,
         PacketLatest,
+        PacketLatestKind,
         RawPacketLatest,
     },
+    events::LazyDeserializedPacket,
     init::SplinterSystem,
     proxy::{
         ClientKickReason,
@@ -109,34 +111,54 @@ pub async fn watch_dummy(client: Arc<SplinterClient>, dummy_conn: Arc<SplinterSe
                 break debug!("dummy conn {} no longer alive", dummy_conn.server.id);
             }
             let mut lock = dummy_conn.reader.lock().await;
-            match lock.read_packet_async::<RawPacketLatest>().await {
-                Ok(Some(packet)) => match packet {
-                    PacketLatest::PlayServerKeepAlive(body) => {
-                        let mut writer = dummy_conn.writer.lock().await;
-                        if let Err(e) = (*writer).write_packet_async(PacketLatest::PlayClientKeepAlive(PlayClientKeepAliveSpec {
-                            id: body.id
-                        })).await {
-                            dummy_conn.alive.store(Arc::new(false));
-                            break error!("Failed to send keep alive for dummy client between {} and server {}: {}", &client.name, dummy_conn.server.id, e);
-                        }
-                    }
-                    _ => {
-                        //ignore all other packets
-                    }
-                }
+            let raw_packet = match lock.read_raw_packet_async::<RawPacketLatest>().await {
+                Ok(Some(packet)) => packet,
                 Ok(None) => {
                     dummy_conn.alive.store(Arc::new(false));
                     break debug!("Dummy connection between {} and server {} closed", &client.name, dummy_conn.server.id);
                 }
                 Err(e) => {
-                    dummy_conn.alive.store(Arc::new(false));
-                    break error!(
-                        "Error reading incoming packet for dummy connection between {} and server {}: {}",
-                        &client.name, dummy_conn.server.id, e
-                    )
+                    error!("{}-{} failed to read next raw packet: {}", &client.name, dummy_conn.server.id, e);
+                    continue;
+                },
+            };
+            let mut lazy_packet = LazyDeserializedPacket::from_raw_packet(raw_packet);
+            let packet_kind = lazy_packet.kind();
+            match packet_kind {
+                PacketLatestKind::PlayServerKeepAlive => match lazy_packet.packet() {
+                    Ok(packet) => match packet {
+                        PacketLatest::PlayServerKeepAlive(body) => {
+                            let mut writer = dummy_conn.writer.lock().await;
+                            debug!("{}-{} got keep alive", &client.name, dummy_conn.server.id);
+                            if let Err(e) = (*writer).write_packet_async(PacketLatest::PlayClientKeepAlive(PlayClientKeepAliveSpec {
+                                id: body.id
+                            })).await {
+                                dummy_conn.alive.store(Arc::new(false));
+                                break error!("Failed to send keep alive for dummy client between {} and server {}: {}", &client.name, dummy_conn.server.id, e);
+                            }
+                        }
+                        _ => {}
+                    }
+                    Err(e) => {
+                        dummy_conn.alive.store(Arc::new(false));
+                        break error!(
+                            "{}-{} failed deserialize packet (type {:?}): {:?}",
+                            &client.name, dummy_conn.server.id, packet_kind, e
+                        )
+                    }
+                }
+                PacketLatestKind::PlayChunkData
+                    | PacketLatestKind::PlayUpdateLight
+                    | PacketLatestKind::PlayTimeUpdate
+                    | PacketLatestKind::PlayUnloadChunk => {
+                    // dont print this
+                }
+                _kind => {
+                    // debug!("{}-{} receive: {:?}", &client.name, dummy_conn.server.id, kind);
                 }
             }
         }
+        client.dummy_servers.lock().await.remove(&dummy_conn.server.id);
         debug!("Closing dummy watch on {} for server {}", &client.name, dummy_conn.server.id);
     })
     .detach()

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -158,7 +158,8 @@ pub async fn watch_dummy(client: Arc<SplinterClient>, dummy_conn: Arc<SplinterSe
                 }
             }
         }
-        client.dummy_servers.lock().await.remove(&dummy_conn.server.id);
+        client.grab_dummy(dummy_conn.server.id).unwrap();
+        // client.dummy_servers.lock().await.remove(&dummy_conn.server.id);
         debug!("Closing dummy watch on {} for server {}", &client.name, dummy_conn.server.id);
     })
     .detach()

--- a/src/protocol/login.rs
+++ b/src/protocol/login.rs
@@ -1,10 +1,12 @@
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{
+        atomic::AtomicBool,
+        Arc,
+    },
 };
 
 use anyhow::Context;
-use arc_swap::ArcSwap;
 use craftio_rs::CraftIo;
 use futures_lite::future;
 use mcproto_rs::{
@@ -84,8 +86,8 @@ impl<'a> ClientBuilder<'a> {
         let mut server_conn = SplinterServerConnection {
             writer: Mutex::new(server_writer),
             reader: Mutex::new(server_reader),
-            server: Arc::clone(&server),
-            alive: ArcSwap::new(Arc::new(true)),
+            server: (*server).clone(),
+            alive: AtomicBool::new(true),
         };
         info!(
             "Connection for client \"{}\" initiated with {}",

--- a/src/protocol/login.rs
+++ b/src/protocol/login.rs
@@ -88,6 +88,8 @@ impl<'a> ClientBuilder<'a> {
             reader: Mutex::new(server_reader),
             server: (*server).clone(),
             alive: AtomicBool::new(true),
+            eid: -1,
+            uuid: UUID4::from(0u128),
         };
         info!(
             "Connection for client \"{}\" initiated with {}",

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -120,7 +120,7 @@ impl SplinterClient {
                 Ok(Some(())) => {}
                 Ok(None) => break, // connection closed
                 Err(e) => {
-                    error!("Failed to handle packet from server: {}", e);
+                    error!("Failed to handle packet from server: {:?}", e);
                 }
             }
         }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -5,7 +5,10 @@ use std::{
         SocketAddr,
         TcpStream,
     },
-    sync::Arc,
+    sync::{
+        atomic::Ordering,
+        Arc,
+    },
 };
 
 use async_compat::Compat;
@@ -107,11 +110,11 @@ impl SplinterClient {
         server_conn: Arc<SplinterServerConnection>,
         client: Arc<SplinterClient>,
     ) -> anyhow::Result<()> {
-        let server = Arc::clone(&server_conn.server);
+        let server = server_conn.server.clone();
         let sender = PacketDirection::ClientBound;
         loop {
             // server->proxy->client
-            if !**self.alive.load() || !**server_conn.alive.load() {
+            if !self.alive.load(Ordering::Relaxed) || !server_conn.alive.load(Ordering::Relaxed) {
                 break;
             }
             let active_server = client.active_server.load();
@@ -124,7 +127,7 @@ impl SplinterClient {
                 }
             }
         }
-        server_conn.alive.store(Arc::new(false));
+        server_conn.alive.store(false, Ordering::Relaxed);
         debug!(
             "Server connection between {} and server id {} closed",
             self.name, server.id
@@ -139,7 +142,7 @@ impl SplinterClient {
         let sender = PacketDirection::ServerBound;
         loop {
             // client->proxy->server
-            if !**self.alive.load() {
+            if !self.alive.load(Ordering::Relaxed) {
                 break;
             }
             match v_cur::handle_client_packet(&proxy, self, &mut client_reader, &sender).await {
@@ -154,7 +157,7 @@ impl SplinterClient {
             }
         }
         proxy.players.write().await.remove(&self.name);
-        self.alive.store(Arc::new(false));
+        self.alive.store(false, Ordering::Relaxed);
         info!("Client \"{}\" connection closed", self.name);
         Ok(())
     }

--- a/src/protocol/v_cur/chat.rs
+++ b/src/protocol/v_cur/chat.rs
@@ -1,6 +1,9 @@
 use craftio_rs::CraftAsyncWriter;
 
-use super::RelayPass;
+use super::{
+    PacketDestination,
+    RelayPass,
+};
 use crate::{
     chat::{
         receive_chat_message,
@@ -28,7 +31,7 @@ inventory::submit! {
                     error!("Failed to deserialize chat message: {}", e);
                 }
             }
-            *destination = None;
+            *destination = PacketDestination::None;
         }
     }))
 }

--- a/src/protocol/v_cur/eid.rs
+++ b/src/protocol/v_cur/eid.rs
@@ -1,4 +1,7 @@
-use super::RelayPass;
+use super::{
+    PacketDestination,
+    RelayPass,
+};
 use crate::{
     client::SplinterClient,
     current::{
@@ -21,9 +24,9 @@ inventory::submit! {
         if has_eids(lazy_packet.kind()) {
             if let Ok(ref mut packet) = lazy_packet.packet() {
                 let mut map = smol::block_on(proxy.mapping.lock());
-                if let Some(_server_id) = map_eid(&*client, &mut map, packet, sender) {
-                    // *destination = PacketDestination::Server(server_id);
-                    *destination = None; // do something here?
+                if let Some(server_id) = map_eid(&*client, &mut map, packet, sender) {
+                    *destination = PacketDestination::Server(server_id);
+                    // *destination = None; // do something here?
                 }
             }
         }
@@ -146,11 +149,11 @@ pub fn map_eid(
                     // debug!("entity spawn type: {}", entity_type);
                     (
                         match entity_type {
-                            107 => {
+                            112 => {
                                 // bobber
                                 vec![&mut body.data]
                             }
-                            2 | 79 | 39 | 76 | 15 | 99 => {
+                            2 | 84 | 43 | 81 | 16 | 104 => {
                                 // arrow, spectral arrow, fireball, small fireball, dragon fireball, wither skull
                                 if body.data > 0 {
                                     // body.data is option varint. we need to specially handle this
@@ -170,7 +173,7 @@ pub fn map_eid(
                 PacketLatest::PlaySpawnExperienceOrb(body) => {
                     entity_data = Some(EntityData {
                         id: *body.entity_id,
-                        entity_type: 24,
+                        entity_type: 25,
                     });
                     (vec![], vec![&mut body.entity_id])
                 }
@@ -184,14 +187,14 @@ pub fn map_eid(
                 PacketLatest::PlaySpawnPainting(body) => {
                     entity_data = Some(EntityData {
                         id: *body.entity_id,
-                        entity_type: 55,
+                        entity_type: 60,
                     });
                     (vec![], vec![&mut body.entity_id])
                 }
                 PacketLatest::PlaySpawnPlayer(body) => {
                     entity_data = Some(EntityData {
                         id: *body.entity_id,
-                        entity_type: 106,
+                        entity_type: 111,
                     });
                     (vec![], vec![&mut body.entity_id])
                 }
@@ -202,7 +205,7 @@ pub fn map_eid(
                     body.entity_id = proxy_eid.into();
                     if let Some(data) = map.entity_data.get(&proxy_eid) {
                         match data.entity_type {
-                            27 => {
+                            28 => {
                                 // fireworks
                                 if let Some(EntityMetadataFieldData::OptVarInt(ref mut id)) =
                                     body.metadata.get_mut(9)
@@ -216,7 +219,7 @@ pub fn map_eid(
                                     }
                                 }
                             }
-                            107 => {
+                            112 => {
                                 // fishing hook
                                 if let Some(EntityMetadataFieldData::VarInt(ref mut id)) =
                                     body.metadata.get_mut(8)
@@ -230,7 +233,7 @@ pub fn map_eid(
                                     }
                                 }
                             }
-                            97 => {
+                            102 => {
                                 // wither
                                 for index in [16, 17, 18] {
                                     if let Some(EntityMetadataFieldData::VarInt(ref mut id)) =
@@ -246,7 +249,7 @@ pub fn map_eid(
                                     }
                                 }
                             }
-                            31 | 17 => {
+                            35 | 18 => {
                                 // guardian or elder guardian
                                 if let Some(EntityMetadataFieldData::VarInt(ref mut id)) =
                                     body.metadata.get_mut(17)

--- a/src/protocol/v_cur/keepalive.rs
+++ b/src/protocol/v_cur/keepalive.rs
@@ -19,7 +19,7 @@ inventory::submit! {
             PacketDirection::ServerBound => {
                 if lazy_packet.kind() == PacketLatestKind::PlayClientKeepAlive { // TODO: may want to do something with the keep alive IDs
                     *smol::block_on(client.last_keep_alive.lock()) = unix_time_millis();
-                    *destination = None;
+                    *destination = v_cur::PacketDestination::None;
                 }
             }
             PacketDirection::ClientBound => {

--- a/src/protocol/v_cur/login.rs
+++ b/src/protocol/v_cur/login.rs
@@ -83,6 +83,7 @@ pub async fn handle_client_login_packet(
                 *next_sender = PacketDirection::ClientBound;
             }
             PacketLatest::LoginSuccess(body) => {
+                builder.server_conn.as_mut().unwrap().uuid = body.uuid;
                 builder.proxy.mapping.lock().await.uuids.insert(
                     builder.uuid.unwrap(),
                     (builder.server_conn.as_ref().unwrap().server.id, body.uuid),
@@ -92,6 +93,7 @@ pub async fn handle_client_login_packet(
                 *next_sender = PacketDirection::ClientBound;
             }
             PacketLatest::PlayJoinGame(mut body) => {
+                builder.server_conn.as_mut().unwrap().eid = body.entity_id;
                 body.entity_id = builder.proxy.mapping.lock().await.map_eid_server_to_proxy(
                     builder.server_conn.as_ref().unwrap().server.id,
                     body.entity_id,

--- a/src/protocol/v_cur/login.rs
+++ b/src/protocol/v_cur/login.rs
@@ -113,6 +113,10 @@ pub async fn handle_client_login_packet(
                 //..
                 *next_sender = PacketDirection::ServerBound;
             }
+            PacketLatest::PlayServerPluginMessage(_body) => {
+                //..
+                *next_sender = PacketDirection::ClientBound;
+            }
             PacketLatest::PlayClientSettings(body) => {
                 builder.play_client_settings(body.clone().into()).await?;
                 *next_sender = PacketDirection::ClientBound;

--- a/src/protocol/v_cur/mod.rs
+++ b/src/protocol/v_cur/mod.rs
@@ -89,6 +89,14 @@ pub async fn handle_client_status(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PacketDestination {
+    None,
+    Server(u64),
+    AllServers,
+    Client,
+}
+
 type RelayPassFn = Box<
     dyn Send
         + Sync
@@ -98,7 +106,7 @@ type RelayPassFn = Box<
             &Arc<SplinterClient>,
             &PacketDirection,
             &mut LazyDeserializedPacket,
-            &mut Option<PacketDirection>,
+            &mut PacketDestination,
         ),
 >;
 pub struct RelayPass(pub RelayPassFn);
@@ -119,7 +127,7 @@ pub async fn handle_server_packet(
     match packet_opt {
         Some(raw_packet) => {
             let mut lazy_packet = LazyDeserializedPacket::from_raw_packet(raw_packet);
-            let mut destination = Some(*sender);
+            let mut destination = PacketDestination::Client;
             for pass in inventory::iter::<RelayPass> {
                 (pass.0)(
                     proxy,
@@ -130,11 +138,15 @@ pub async fn handle_server_packet(
                     &mut destination,
                 );
             }
-            if let Some(dir) = destination {
-                send_packet(client, &dir, lazy_packet)
-                    .await
-                    .with_context(|| format!("Sending packet {} failure", server.id))?;
-            }
+            let kind = lazy_packet.kind();
+            send_packet(client, &destination, lazy_packet)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Sending packet kind {:?} for client {} to destination {:?} failure",
+                        kind, &client.name, destination
+                    )
+                })?;
             Ok(Some(()))
         }
         None => Ok(None),
@@ -154,7 +166,7 @@ pub async fn handle_client_packet(
     match packet_opt {
         Some(raw_packet) => {
             let mut lazy_packet = LazyDeserializedPacket::from_raw_packet(raw_packet);
-            let mut destination = Some(*sender);
+            let mut destination = PacketDestination::AllServers;
             for pass in inventory::iter::<RelayPass> {
                 (pass.0)(
                     proxy,
@@ -165,45 +177,66 @@ pub async fn handle_client_packet(
                     &mut destination,
                 );
             }
-            if let Some(dir) = destination {
-                send_packet(client, &dir, lazy_packet)
-                    .await
-                    .with_context(|| {
-                        format!("Sending packet from client \"{}\" failure", &client.name)
-                    })?;
-            }
+            send_packet(client, &destination, lazy_packet)
+                .await
+                .with_context(|| {
+                    format!("Sending packet from client \"{}\" failure", &client.name)
+                })?;
             Ok(Some(()))
         }
         None => Ok(None),
     }
 }
 
-async fn send_packet(
+async fn send_packet<'a>(
     client: &Arc<SplinterClient>,
-    destination: &PacketDirection,
-    lazy_packet: LazyDeserializedPacket<'_>,
+    destination: &PacketDestination,
+    lazy_packet: LazyDeserializedPacket<'a>,
 ) -> anyhow::Result<()> {
     match destination {
-        PacketDirection::ClientBound => {
+        PacketDestination::Client => {
             write_packet(&mut *client.writer.lock().await, lazy_packet)
                 .await
                 .with_context(|| {
                     format!("Failed to write packet to client \"{}\"", &client.name,)
                 })?;
         }
-        PacketDirection::ServerBound => {
-            write_packet(
-                &mut *client.active_server.load().writer.lock().await,
-                lazy_packet,
-            )
-            .await
-            .with_context(|| {
+        PacketDestination::Server(server_id) => {
+            let active_server = client.active_server.load();
+            let dummy_lock = client.dummy_servers.lock().await; // yuck
+            let writer = &mut *(if active_server.server.id == *server_id {
+                active_server.writer.lock().await
+            } else {
+                if let Some(server_conn) = dummy_lock.get(server_id) {
+                    server_conn.writer.lock().await
+                } else {
+                    bail!("No connected server from mapped server id");
+                }
+            });
+            write_packet(writer, lazy_packet)
+                .await
+                .with_context(|| format!("Failed to write packet to server \"{}\"", server_id))?;
+        }
+        PacketDestination::AllServers => {
+            for (server_id, server_conn) in client.dummy_servers.lock().await.iter() {
+                let writer = &mut *server_conn.writer.lock().await;
+                write_packet(writer, lazy_packet.clone())
+                    .await
+                    .with_context(|| {
+                        format!("Failed to write packet to server \"{}\"", server_id)
+                    })?;
+            }
+            let active_server = client.active_server.load();
+            let writer = &mut *active_server.writer.lock().await;
+
+            write_packet(writer, lazy_packet).await.with_context(|| {
                 format!(
                     "Failed to write packet to server \"{}\"",
-                    client.server_id()
+                    active_server.server.id
                 )
             })?;
         }
+        PacketDestination::None => {}
     };
     Ok(())
 }

--- a/src/protocol/v_cur/mod.rs
+++ b/src/protocol/v_cur/mod.rs
@@ -117,7 +117,7 @@ pub async fn handle_server_packet(
     proxy: &Arc<SplinterProxy>,
     client: &Arc<SplinterClient>,
     reader: &mut AsyncCraftReader,
-    server: &Arc<SplinterServer>,
+    server: &SplinterServer,
     sender: &PacketDirection,
 ) -> anyhow::Result<Option<()>> {
     let packet_opt = reader

--- a/src/protocol/v_cur/sync.rs
+++ b/src/protocol/v_cur/sync.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use super::RelayPass;
 use crate::current::proto::{
@@ -11,10 +11,10 @@ inventory::submit! {
         if lazy_packet.kind() == PacketLatestKind::PlayServerHeldItemChange || lazy_packet.kind() == PacketLatestKind::PlayClientHeldItemChange {
             match lazy_packet.packet() {
                 Ok(PacketLatest::PlayServerHeldItemChange(body)) => {
-                    client.held_slot.store(Arc::new(body.slot));
+                    client.held_slot.store(body.slot, Ordering::Relaxed);
                 },
                 Ok(PacketLatest::PlayClientHeldItemChange(body)) => {
-                    client.held_slot.store(Arc::new(body.slot as i8));
+                    client.held_slot.store(body.slot as i8, Ordering::Relaxed);
                 },
                 Ok(_) => unreachable!(),
                 Err(e) => error!("Failed to deserialize held item message: {}", e),

--- a/src/protocol/v_cur/uuid.rs
+++ b/src/protocol/v_cur/uuid.rs
@@ -1,4 +1,7 @@
-use super::RelayPass;
+use super::{
+    PacketDestination,
+    RelayPass,
+};
 use crate::{
     client::SplinterClient,
     current::{
@@ -19,9 +22,8 @@ inventory::submit! {
         if has_uuids(lazy_packet.kind()) {
             if let Ok(ref mut packet) = lazy_packet.packet() {
                 let mut map = smol::block_on(proxy.mapping.lock());
-                if let Some(_server_id) = map_uuid(&*client, &mut *map, packet, sender) {
-                    // *destination = PacketDestination::Server(server_id);
-                    *destination = None; // do something here?
+                if let Some(server_id) = map_uuid(&*client, &mut *map, packet, sender) {
+                    *destination = PacketDestination::Server(server_id);
                 }
             }
         }
@@ -64,13 +66,13 @@ pub fn map_uuid(
                     let proxy_eid = body.entity_id;
                     if let Some(data) = map.entity_data.get(&proxy_eid) {
                         match data.entity_type {
-                            33 //horse
-                                | 103 // zombie horse
-                                | 74 // skeleton horse
-                                | 14 // donkey
-                                | 42 // llama
-                                | 79 // trader llama
-                                | 52 // mule 
+                            37 //horse
+                                | 108 // zombie horse
+                                | 79 // skeleton horse
+                                | 15 // donkey
+                                | 46 // llama
+                                | 94 // trader llama
+                                | 57 // mule 
                                 => {
                                 if let Some(EntityMetadataFieldData::OptUUID(Some(ref mut uuid))) = body.metadata.get_mut(18) {
                                     Some(uuid)
@@ -79,7 +81,7 @@ pub fn map_uuid(
                                     None
                                 }
                             }
-                            28 => { // fox
+                            29 => { // fox
                                 for index in [19, 20] {
                                     if let Some(EntityMetadataFieldData::OptUUID(Some(ref mut uuid))) = body.metadata.get_mut(index) {
                                         *uuid = map.map_uuid_server_to_proxy(server.id, *uuid);
@@ -88,9 +90,9 @@ pub fn map_uuid(
                                 }
                                 None
                             }
-                            7 // cat
-                                | 100 // wolf
-                                | 57 // parrot
+                            8 // cat
+                                | 105 // wolf
+                                | 62 // parrot
                                 => {
                                 if let Some(EntityMetadataFieldData::OptUUID(Some(ref mut uuid))) = body.metadata.get_mut(18) {
                                     Some(uuid)

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,10 +3,9 @@ use std::{
         SocketAddr,
         TcpStream,
     },
-    sync::Arc,
+    sync::atomic::AtomicBool,
 };
 
-use arc_swap::ArcSwap;
 use async_compat::CompatExt;
 use async_dup::Arc as AsyncArc;
 use craftio_rs::CraftConnection;
@@ -45,8 +44,8 @@ impl SplinterServer {
 pub struct SplinterServerConnection {
     pub writer: Mutex<AsyncCraftWriter>,
     pub reader: Mutex<AsyncCraftReader>,
-    pub server: Arc<SplinterServer>,
-    pub alive: ArcSwap<bool>,
+    pub server: SplinterServer,
+    pub alive: AtomicBool,
 }
 
 impl SplinterServerConnection {

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,7 @@ use smol::{
 };
 
 use crate::{
-    client::SplinterClient,
+    current::uuid::UUID4,
     protocol::{
         AsyncCraftConnection,
         AsyncCraftReader,
@@ -46,10 +46,7 @@ pub struct SplinterServerConnection {
     pub reader: Mutex<AsyncCraftReader>,
     pub server: SplinterServer,
     pub alive: AtomicBool,
-}
 
-impl SplinterServerConnection {
-    pub fn _is_dummy(&self, client: &SplinterClient) -> bool {
-        client.server_id() != self.server.id
-    }
+    pub eid: i32,
+    pub uuid: UUID4,
 }


### PR DESCRIPTION
Resends any packet that does not deal with a UUID or EID to the player's dummies. Packets with a UUID or EID are redirected to the server where the mapped target UUID or EID is.